### PR TITLE
Test 283 increase low coverage unit tests

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -6,4 +6,18 @@ module.exports = {
     '^expo/src/winter/ImportMetaRegistry$': '<rootDir>/test/mocks/expoImportMetaRegistry.ts',
     '^expo/src/winter$': '<rootDir>/test/mocks/expoWinter.ts',
   },
+  collectCoverageFrom: [
+    '<rootDir>/**/*.{ts,tsx}',
+    '!<rootDir>/**/__mocks__/**',
+    '!<rootDir>/**/test/**',
+    '!<rootDir>/**/coverage/**',
+    '!<rootDir>/**/dist/**',
+    '!<rootDir>/**/node_modules/**',
+    '!<rootDir>/**/*.d.ts',
+    '!<rootDir>/**/metro.config.js',
+    '!<rootDir>/**/jest.config.js',
+    '!<rootDir>/**/jest.setup.js',
+    '!<rootDir>/**/tailwind.config.js',
+    '!<rootDir>/**/babel.config.js',
+  ],
 };

--- a/apps/mobile/test/components/bottomTabNavigator.test.tsx
+++ b/apps/mobile/test/components/bottomTabNavigator.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import BottomTabNavigator from '../../components/bottomTabNavigator';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    Ionicons: ({ name, color }: { name: string; color: string }) =>
+      React.createElement(Text, null, `${name}-${color}`),
+  };
+});
+
+jest.mock('../../screens/homeScreen', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return () => React.createElement(Text, null, 'Mock Home Screen');
+});
+
+jest.mock('@react-navigation/bottom-tabs', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    createBottomTabNavigator: () => {
+      const Screen = ({ component: Component, options, name }: any) => {
+        const icon = options?.tabBarIcon ? options.tabBarIcon({ color: 'white' }) : null;
+        return (
+          <>
+            <Text>{name}</Text>
+            {icon}
+            <Component />
+          </>
+        );
+      };
+
+      const Navigator = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+      return { Navigator, Screen };
+    },
+  };
+});
+
+describe('BottomTabNavigator', () => {
+  it('renders all tab screens and their icons', () => {
+    const { getByText } = render(<BottomTabNavigator />);
+
+    expect(getByText('Library')).toBeTruthy();
+    expect(getByText('bookmark-outline-white')).toBeTruthy();
+
+    expect(getByText('Home')).toBeTruthy();
+    expect(getByText('home-outline-white')).toBeTruthy();
+    expect(getByText('Mock Home Screen')).toBeTruthy();
+
+    expect(getByText('Liked')).toBeTruthy();
+    expect(getByText('heart-outline-white')).toBeTruthy();
+    expect(getByText('Liked Screen')).toBeTruthy();
+  });
+});

--- a/apps/mobile/test/screens/homeScreen.test.tsx
+++ b/apps/mobile/test/screens/homeScreen.test.tsx
@@ -1,0 +1,142 @@
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import HomeScreen from '../../screens/homeScreen';
+import { Mantra } from '../../services/mantra.service';
+
+const mockGetFeedMantras = jest.fn();
+const mockLikeMantra = jest.fn().mockResolvedValue({ status: 'success' });
+const mockUnlikeMantra = jest.fn().mockResolvedValue({ status: 'success' });
+const mockSaveMantra = jest.fn().mockResolvedValue({ status: 'success' });
+const mockUnsaveMantra = jest.fn().mockResolvedValue({ status: 'success' });
+const mockGetToken = jest.fn();
+
+jest.mock('../../services/mantra.service', () => ({
+  mantraService: {
+    getFeedMantras: (...args: unknown[]) => mockGetFeedMantras(...args),
+    likeMantra: (...args: unknown[]) => mockLikeMantra(...args),
+    unlikeMantra: (...args: unknown[]) => mockUnlikeMantra(...args),
+    saveMantra: (...args: unknown[]) => mockSaveMantra(...args),
+    unsaveMantra: (...args: unknown[]) => mockUnsaveMantra(...args),
+  },
+}));
+
+jest.mock('../../utils/storage', () => ({
+  storage: {
+    getToken: (...args: unknown[]) => mockGetToken(...args),
+  },
+}));
+
+jest.mock('../../components/carousel', () => {
+  const React = jest.requireActual('react');
+  const { Text, TouchableOpacity, View } = jest.requireActual('react-native');
+  return ({ item, onLike, onSave }: any) =>
+    React.createElement(
+      View,
+      null,
+      React.createElement(Text, null, item.title),
+      React.createElement(
+        TouchableOpacity,
+        { testID: `mock-like-${item.mantra_id}`, onPress: () => onLike(item.mantra_id) },
+        React.createElement(Text, null, 'Like'),
+      ),
+      React.createElement(
+        TouchableOpacity,
+        { testID: `mock-save-${item.mantra_id}`, onPress: () => onSave(item.mantra_id) },
+        React.createElement(Text, null, 'Save'),
+      ),
+    );
+});
+
+describe('HomeScreen', () => {
+  const mantra: Mantra = {
+    mantra_id: 10,
+    title: 'Stay Focused',
+    key_takeaway: 'Concentrate on the task in front of you.',
+    created_at: '2024-01-01T00:00:00Z',
+    is_active: true,
+    isLiked: false,
+    isSaved: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetToken.mockResolvedValue('token-123');
+    mockGetFeedMantras.mockResolvedValue({ status: 'success', data: [mantra] });
+  });
+
+  it('shows loading state while fetching data', async () => {
+    let resolveMantras: (value: unknown) => void = () => {};
+    mockGetFeedMantras.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMantras = resolve;
+        }),
+    );
+
+    const { getByText } = render(<HomeScreen />);
+
+    expect(getByText('Loading mantras...')).toBeTruthy();
+
+    await act(async () => {
+      resolveMantras({ status: 'success', data: [] });
+    });
+  });
+
+  it('renders the empty state when no mantras are returned', async () => {
+    mockGetFeedMantras.mockResolvedValueOnce({ status: 'success', data: [] });
+
+    const { getByText } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No mantras available')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Refresh'));
+    await waitFor(() => expect(mockGetFeedMantras).toHaveBeenCalledTimes(2));
+  });
+
+  it('loads mantras and handles like/save interactions', async () => {
+    const { getByText, getByTestId } = render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Stay Focused')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('mock-like-10'));
+    await waitFor(() => {
+      expect(mockLikeMantra).toHaveBeenCalledWith(10, 'token-123');
+    });
+
+    fireEvent.press(getByTestId('mock-like-10'));
+    await waitFor(() => {
+      expect(mockUnlikeMantra).toHaveBeenCalledWith(10, 'token-123');
+    });
+
+    fireEvent.press(getByTestId('mock-save-10'));
+    await waitFor(() => {
+      expect(mockSaveMantra).toHaveBeenCalledWith(10, 'token-123');
+    });
+
+    fireEvent.press(getByTestId('mock-save-10'));
+    await waitFor(() => {
+      expect(mockUnsaveMantra).toHaveBeenCalledWith(10, 'token-123');
+    });
+  });
+
+  it('shows an alert when toggling like fails', async () => {
+    mockLikeMantra.mockRejectedValueOnce(new Error('Network issue'));
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const { getByTestId } = render(<HomeScreen />);
+
+    await waitFor(() => expect(getByTestId('mock-like-10')).toBeTruthy());
+
+    fireEvent.press(getByTestId('mock-like-10'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Error', 'Failed to update like status');
+    });
+
+    alertSpy.mockRestore();
+  });
+});

--- a/apps/mobile/test/services/api.config.test.ts
+++ b/apps/mobile/test/services/api.config.test.ts
@@ -1,0 +1,88 @@
+/* global require */
+
+describe('api.config', () => {
+  const loadModule = (platform: 'android' | 'ios' | 'web' = 'web') => {
+    jest.resetModules();
+
+    const requestHandlers: Array<{
+      fulfilled: (config: any) => any;
+      rejected: (error: any) => any;
+    }> = [];
+    const responseHandlers: Array<{
+      fulfilled: (response: any) => any;
+      rejected: (error: any) => any;
+    }> = [];
+
+    const requestUse = jest.fn((fulfilled, rejected) => {
+      requestHandlers.push({ fulfilled, rejected });
+    });
+    const responseUse = jest.fn((fulfilled, rejected) => {
+      responseHandlers.push({ fulfilled, rejected });
+    });
+
+    const mockCreate = jest.fn(() => ({
+      interceptors: {
+        request: { use: requestUse },
+        response: { use: responseUse },
+      },
+    }));
+
+    jest.doMock('axios', () => ({
+      create: mockCreate,
+    }));
+
+    jest.doMock('react-native', () => ({
+      Platform: { OS: platform },
+    }));
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    let apiClient: any;
+    jest.isolateModules(() => {
+      ({ apiClient } = require('../../services/api.config'));
+    });
+
+    return { mockCreate, apiClient, requestHandlers, responseHandlers, consoleSpy };
+  };
+
+  it('configures base URL for Android', () => {
+    const { mockCreate, consoleSpy } = loadModule('android');
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'http://10.0.2.2:4000/api' }),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('configures base URL for iOS', () => {
+    const { mockCreate, consoleSpy } = loadModule('ios');
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'http://localhost:4000/api' }),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('passes through request and handles errors via interceptors', async () => {
+    const { requestHandlers, consoleSpy } = loadModule('ios');
+    const handler = requestHandlers[0];
+
+    const config = { url: '/health' };
+    await expect(handler.fulfilled(config)).resolves.toBe(config);
+
+    await expect(handler.rejected(new Error('bad request'))).rejects.toThrow('bad request');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns responses and handles unauthorized errors', async () => {
+    const { responseHandlers, consoleSpy } = loadModule('android');
+    const handler = responseHandlers[0];
+
+    const response = { data: 'ok' };
+    expect(handler.fulfilled(response)).toBe(response);
+
+    const error = { response: { status: 401 } };
+    await expect(handler.rejected(error)).rejects.toEqual(error);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/mobile/test/services/auth.service.test.ts
+++ b/apps/mobile/test/services/auth.service.test.ts
@@ -1,0 +1,65 @@
+import { authService } from '../../services/auth.service';
+
+const mockPost = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('../../services/api.config', () => ({
+  apiClient: {
+    post: (...args: unknown[]) => mockPost(...args),
+    get: (...args: unknown[]) => mockGet(...args),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+  },
+}));
+
+describe('authService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls the login endpoint and returns the response data', async () => {
+    const payload = { email: 'user@example.com', password: 'secret' };
+    const data = { status: 'success' };
+    mockPost.mockResolvedValueOnce({ data });
+
+    const result = await authService.login(payload);
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/login', payload);
+    expect(result).toBe(data);
+  });
+
+  it('calls the register endpoint and returns the response data', async () => {
+    const payload = { username: 'newuser', email: 'new@example.com', password: 'pass123' };
+    const data = { status: 'success' };
+    mockPost.mockResolvedValueOnce({ data });
+
+    const result = await authService.register(payload);
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/register', payload);
+    expect(result).toBe(data);
+  });
+
+  it('calls the getMe endpoint with the provided token', async () => {
+    const data = { status: 'success' };
+    mockGet.mockResolvedValueOnce({ data });
+
+    const result = await authService.getMe('jwt-token');
+
+    expect(mockGet).toHaveBeenCalledWith('/auth/me', {
+      headers: { Authorization: 'Bearer jwt-token' },
+    });
+    expect(result).toBe(data);
+  });
+
+  it('calls the googleAuth endpoint and returns the response data', async () => {
+    const data = { status: 'success' };
+    mockPost.mockResolvedValueOnce({ data });
+
+    const result = await authService.googleAuth({ idToken: 'google-token' });
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/google', { idToken: 'google-token' });
+    expect(result).toBe(data);
+  });
+});

--- a/apps/mobile/test/services/google-auth.service.test.ts
+++ b/apps/mobile/test/services/google-auth.service.test.ts
@@ -1,0 +1,66 @@
+/* global require */
+
+describe('useGoogleAuth', () => {
+  it('delegates to the Expo auth request hook', () => {
+    jest.resetModules();
+
+    const mockUseAuthRequest = jest.fn(() => ['request', 'response', jest.fn()]);
+    const mockMaybeCompleteAuthSession = jest.fn();
+
+    jest.doMock('expo-auth-session/providers/google', () => ({
+      useAuthRequest: mockUseAuthRequest,
+    }));
+
+    jest.doMock('expo-web-browser', () => ({
+      maybeCompleteAuthSession: mockMaybeCompleteAuthSession,
+    }));
+
+    jest.isolateModules(() => {
+      const { useGoogleAuth } = require('../../services/google-auth.service');
+      const result = useGoogleAuth();
+
+      expect(mockMaybeCompleteAuthSession).toHaveBeenCalled();
+      expect(mockUseAuthRequest).toHaveBeenCalledWith({
+        androidClientId: '837744591033-ju2acrfhaivd2hhc87f5hrhltgp5bu00.apps.googleusercontent.com',
+        iosClientId: '837744591033-vbeh1un6ghnm6t5q86cd5b0ub102m600.apps.googleusercontent.com',
+        scopes: ['profile', 'email'],
+      });
+      expect(result.request).toBe('request');
+      expect(result.response).toBe('response');
+      expect(typeof result.promptAsync).toBe('function');
+    });
+  });
+});
+
+describe('fetchGoogleUserInfo', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns parsed json when the response is ok', async () => {
+    jest.resetModules();
+    const data = { name: 'Google User' };
+    const mockJson = jest.fn().mockResolvedValue(data);
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, json: mockJson }) as any;
+
+    const { fetchGoogleUserInfo } = require('../../services/google-auth.service');
+
+    const result = await fetchGoogleUserInfo('access-token');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://www.googleapis.com/userinfo/v2/me', {
+      headers: { Authorization: 'Bearer access-token' },
+    });
+    expect(result).toEqual(data);
+  });
+
+  it('throws an error when the response is not ok', async () => {
+    jest.resetModules();
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false }) as any;
+
+    const { fetchGoogleUserInfo } = require('../../services/google-auth.service');
+
+    await expect(fetchGoogleUserInfo('bad-token')).rejects.toThrow('Failed to fetch user info');
+  });
+});

--- a/apps/mobile/test/services/mantra.service.test.ts
+++ b/apps/mobile/test/services/mantra.service.test.ts
@@ -1,0 +1,40 @@
+/* global require */
+
+let mantraService: typeof import('../../services/mantra.service').mantraService;
+
+describe('mantraService (mock implementation)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ({ mantraService } = require('../../services/mantra.service'));
+  });
+
+  it('returns mock mantra data with success status', async () => {
+    const response = await mantraService.getFeedMantras('token');
+    expect(response.status).toBe('success');
+    expect(response.data.length).toBeGreaterThan(0);
+  });
+
+  it('toggles liked state through like/unlike helpers', async () => {
+    await mantraService.likeMantra(1, 'token');
+    let response = await mantraService.getFeedMantras('token');
+    const likedMantra = response.data.find((m) => m.mantra_id === 1);
+    expect(likedMantra?.isLiked).toBe(true);
+
+    await mantraService.unlikeMantra(1, 'token');
+    response = await mantraService.getFeedMantras('token');
+    const unlikedMantra = response.data.find((m) => m.mantra_id === 1);
+    expect(unlikedMantra?.isLiked).toBe(false);
+  });
+
+  it('toggles saved state through save/unsave helpers', async () => {
+    await mantraService.saveMantra(2, 'token');
+    let response = await mantraService.getFeedMantras('token');
+    const savedMantra = response.data.find((m) => m.mantra_id === 2);
+    expect(savedMantra?.isSaved).toBe(true);
+
+    await mantraService.unsaveMantra(2, 'token');
+    response = await mantraService.getFeedMantras('token');
+    const unsavedMantra = response.data.find((m) => m.mantra_id === 2);
+    expect(unsavedMantra?.isSaved).toBe(false);
+  });
+});

--- a/apps/mobile/test/utils/storage.test.ts
+++ b/apps/mobile/test/utils/storage.test.ts
@@ -1,0 +1,55 @@
+import { storage } from '../../utils/storage';
+
+const mockSetItem = jest.fn();
+const mockGetItem = jest.fn();
+const mockRemoveItem = jest.fn();
+const mockMultiRemove = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  removeItem: (...args: unknown[]) => mockRemoveItem(...args),
+  multiRemove: (...args: unknown[]) => mockMultiRemove(...args),
+}));
+
+describe('storage utility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('saves and retrieves a token', async () => {
+    mockGetItem.mockResolvedValueOnce('jwt-value');
+
+    await storage.saveToken('jwt-value');
+    const token = await storage.getToken();
+
+    expect(mockSetItem).toHaveBeenCalledWith('@auth_token', 'jwt-value');
+    expect(mockGetItem).toHaveBeenCalledWith('@auth_token');
+    expect(token).toBe('jwt-value');
+  });
+
+  it('removes the auth token', async () => {
+    await storage.removeToken();
+    expect(mockRemoveItem).toHaveBeenCalledWith('@auth_token');
+  });
+
+  it('stores and parses user data', async () => {
+    const user = { id: 1, name: 'Tester' };
+    mockGetItem.mockResolvedValueOnce(JSON.stringify(user));
+
+    await storage.saveUserData(user);
+    const result = await storage.getUserData();
+
+    expect(mockSetItem).toHaveBeenCalledWith('@user_data', JSON.stringify(user));
+    expect(mockGetItem).toHaveBeenCalledWith('@user_data');
+    expect(result).toEqual(user);
+  });
+
+  it('removes user data and clears all stored values', async () => {
+    await storage.removeUserData();
+    expect(mockRemoveItem).toHaveBeenCalledWith('@user_data');
+
+    await storage.clearAll();
+    expect(mockMultiRemove).toHaveBeenCalledWith(['@auth_token', '@user_data']);
+  });
+});


### PR DESCRIPTION
## Summary
This pull request introduces unit tests for key components and services in the mobile app, enhancing test coverage and reliability. It includes tests for navigation, screens, service modules, utility functions, and configuration updates for coverage collection.

## Linked Story
Closes #283 

## Changes
**Testing Improvements:**

* Added unit tests for `BottomTabNavigator`, verifying tab rendering and icon display.
* Added tests for `HomeScreen`, including loading states, empty states, mantra interactions, and error handling with mocked dependencies.

**Service Layer Testing:**

* Added tests for `api.config`, verifying URL configuration and interceptor behaviour.
* Verified `authService` API calls for login, registration, and Google authentication.
* Added tests for `mantraService`, ensuring accurate mantra data retrieval and state toggling.

**Utility Function Testing:**

* Tested `storage` utility for storing, retrieving, removing, and clearing values.

**Configuration Updates:**

* Updated `jest.config.js` for coverage collection guidelines.

## Evidence
<img width="541" height="438" alt="image" src="https://github.com/user-attachments/assets/4180b496-2c29-4e66-aa55-9d579bb5a98d" />