### PR TITLE
Replace VARCHAR2 with VARCHAR in init.sql

### DIFF
--- a/apps/backend/database/init.sql
+++ b/apps/backend/database/init.sql
@@ -17,7 +17,7 @@ CREATE TABLE "User" (
 
 CREATE TABLE "Admin" (
   "admin_id" int PRIMARY KEY,
-  "role" VARCHAR2(255)
+  "role" VARCHAR(255)
 );
 
 CREATE TABLE "Mantra" (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,12 +307,6 @@ importers:
         specifier: ~5.9.2
         version: 5.9.2
 
-  backend:
-    dependencies:
-      google-auth-library:
-        specifier: ^10.4.2
-        version: 10.4.2
-
 packages:
 
   '@0no-co/graphql.web@1.2.0':
@@ -1006,7 +1000,6 @@ packages:
   '@esbuild/win32-x64@0.25.10':
     resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
     engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
@@ -3271,10 +3264,7 @@ packages:
     engines: {node: '>=20.16.0'}
 
   expo-splash-screen@31.0.10:
-    resolution:
-      {
-        integrity: sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A==,
-      }
+    resolution: {integrity: sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A==}
     peerDependencies:
       expo: '*'
 


### PR DESCRIPTION
## Summary
Fixes database initialization by replacing Oracle-specific VARCHAR2 with standard VARCHAR syntax.

## Linked Story
Closes [#323](https://github.com/MeMantraa/MeMantra/issues/323)

## Changes
- [x] Bug fix

## Evidence
- Database now initializes successfully in Docker
- No more "type 'varchar2' does not exist" errors

## Tests
- [x] Manual testing: Docker database starts without errors
- [x] CI passing

## Notes
- Critical fix for new developer onboarding
- Blocks all local environment setups without this fix