### PR TITLE
feat: refactor login screen to use TextButton component and enhance A…

### DIFF
--- a/apps/mobile/components/UI/textButton.tsx
+++ b/apps/mobile/components/UI/textButton.tsx
@@ -23,19 +23,17 @@ const TextButton: React.FC<TextButtonProps> = ({
   disabled,
 }) => {
   return (
-    <>
-      <TouchableOpacity
-        activeOpacity={0.7}
-        className={`rounded-full items-center justify-center ${className}`}
-        onPress={onPress}
-        style={style}
-        disabled={disabled}
-      >
-        <AppText className={textClassName} style={textStyle}>
-          {children}
-        </AppText>
-      </TouchableOpacity>
-    </>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      className={`rounded-full items-center justify-center ${className}`}
+      onPress={onPress}
+      style={style}
+      disabled={disabled}
+    >
+      <AppText className={textClassName} style={textStyle}>
+        {children}
+      </AppText>
+    </TouchableOpacity>
   );
 };
 export default TextButton;

--- a/apps/mobile/components/UI/textButton.tsx
+++ b/apps/mobile/components/UI/textButton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { TouchableOpacity, TextStyle, ViewStyle } from 'react-native';
+import type { StyleProp } from 'react-native';
+import AppText from './textWrapper';
+
+type TextButtonProps = {
+  onPress: () => void;
+  className?: string;
+  children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
+  textClassName?: string;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+const TextButton: React.FC<TextButtonProps> = ({
+  onPress,
+  children,
+  className = '',
+  textClassName = '',
+  textStyle,
+  style,
+  disabled,
+}) => {
+  return (
+    <>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        className={`rounded-full items-center justify-center ${className}`}
+        onPress={onPress}
+        style={style}
+        disabled={disabled}
+      >
+        <AppText className={textClassName} style={textStyle}>
+          {children}
+        </AppText>
+      </TouchableOpacity>
+    </>
+  );
+};
+export default TextButton;

--- a/apps/mobile/components/UI/textWrapper.tsx
+++ b/apps/mobile/components/UI/textWrapper.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import { Text, TextProps, StyleSheet } from 'react-native';
+import { cssInterop } from 'nativewind';
 
-export default function AppText(props: Readonly<TextProps>) {
+type AppTextProps = TextProps & {
+  className?: string;
+};
+
+function AppTextBase(props: Readonly<AppTextProps>) {
   return (
     <Text {...props} style={[styles.text, props.style]}>
       {props.children}
     </Text>
   );
 }
+
+const AppText = cssInterop(AppTextBase, { className: 'style' });
+
+export default AppText;
 
 const styles = StyleSheet.create({
   text: {

--- a/apps/mobile/screens/login.tsx
+++ b/apps/mobile/screens/login.tsx
@@ -1,6 +1,6 @@
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect, useState } from 'react';
-import { View, TouchableOpacity, Image, Alert } from 'react-native';
+import { View, Image, Alert } from 'react-native';
 import logo from '../assets/logo.png';
 import googleLogo from '../assets/googleLogo.png';
 import { authService } from '../services/auth.service';

--- a/apps/mobile/screens/login.tsx
+++ b/apps/mobile/screens/login.tsx
@@ -9,6 +9,7 @@ import { useGoogleAuth } from '../services/google-auth.service';
 import { useTheme } from '../context/ThemeContext';
 import AppTextInput from '../components/UI/textInputWrapper';
 import AppText from '../components/UI/textWrapper';
+import TextButton from '../components/UI/textButton';
 
 export default function LoginScreen({ navigation }: any) {
   const [email, setEmail] = useState('');
@@ -130,33 +131,37 @@ export default function LoginScreen({ navigation }: any) {
               editable={!loading}
             />
 
-            <TouchableOpacity
-              style={{ backgroundColor: colors.secondary }}
-              className="rounded-[30px] p-[14px] items-center mt-[8px]"
+            <TextButton
               onPress={handleLogin}
+              className="rounded-[30px] p-[14px] items-center mt-[8px]"
+              textClassName="text-[#fff] text-[18px]"
+              style={{ backgroundColor: colors.secondary }}
               disabled={loading}
             >
-              <AppText className="text-[#ffffff] text-[18px] font-semibold">Login</AppText>
-            </TouchableOpacity>
+              Login
+            </TextButton>
 
-            <TouchableOpacity className="items-center mt-[20px]" onPress={handleSignUp}>
-              <AppText className="text-[#fff] text-[14px]">
-                New to us?
-                <AppText className="text-[#ffffff] text-[14px] font-bold"> Sign Up</AppText>
-              </AppText>
-            </TouchableOpacity>
+            <TextButton
+              className="mt-[16px] items-center"
+              onPress={handleSignUp}
+              textClassName="text-[#fff] text-[14px]"
+              disabled={loading}
+            >
+              New to us? <AppText className="text-white font-black">Sign Up</AppText>
+            </TextButton>
 
-            <TouchableOpacity
+            <TextButton
               className="bg-[#6D7E68] rounded-[30px] p-[12px] mx-[60px] items-center mt-[18px]"
               onPress={handleGoogleSignIn}
               disabled={!request || loading}
+              textClassName="text-[#fff] text-[14px]"
               style={{ backgroundColor: colors.primaryDark }}
             >
               <View className="flex-row items-center">
                 <Image source={googleLogo} className="mr-[10px] w-[30px] h-[30px]" />
                 <AppText className="text-[#fff] text-[14px]">Sign In with Google</AppText>
               </View>
-            </TouchableOpacity>
+            </TextButton>
           </View>
         </View>
       </View>

--- a/apps/mobile/test/components/UI/textButton.test.tsx
+++ b/apps/mobile/test/components/UI/textButton.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { TouchableOpacity } from 'react-native';
+import TextButton from '../../../components/UI/textButton';
+
+describe('TextButton Component', () => {
+  const mockOnPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the button text', () => {
+    const { getByText } = render(<TextButton onPress={mockOnPress}>Login</TextButton>);
+
+    expect(getByText('Login')).toBeTruthy();
+  });
+
+  it('calls onPress when pressed', () => {
+    const { UNSAFE_getByType } = render(<TextButton onPress={mockOnPress}>Login</TextButton>);
+
+    fireEvent.press(UNSAFE_getByType(TouchableOpacity));
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes disabled prop to TouchableOpacity', () => {
+    const { UNSAFE_getByType } = render(
+      <TextButton onPress={mockOnPress} disabled>
+        Login
+      </TextButton>,
+    );
+
+    expect(UNSAFE_getByType(TouchableOpacity).props.disabled).toBe(true);
+  });
+
+  it('applies textStyle overrides', () => {
+    const { getByText } = render(
+      <TextButton onPress={mockOnPress} textStyle={{ color: 'red', fontSize: 18 }}>
+        Login
+      </TextButton>,
+    );
+
+    expect(getByText('Login')).toHaveStyle({ color: 'red', fontSize: 18 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^5.9.2"
   },
   "private": "true",
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
   "dependencies": {
     "google-auth-library": "^10.4.2",
     "react-native-worklets": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^5.9.2"
   },
   "private": "true",
-  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48",
+  "packageManager": "pnpm@9.15.9",
   "dependencies": {
     "google-auth-library": "^10.4.2",
     "react-native-worklets": "^0.6.0"


### PR DESCRIPTION
## Summary
This pull request introduces a reusable `TextButton` component to the mobile app's UI library and refactors the login screen to implement it. Additionally, it enhances the `AppText` component by adding support for the `className` prop for NativeWind, promoting consistency in button styling.

## Linked Story
Closes #318 

## Changes

**UI Component Creation:**
- Added `TextButton` in `components/UI/textButton.tsx`, a styled button using `TouchableOpacity` and `AppText`, with support for custom styles and disabled state.
- Refactored the login screen (`screens/login.tsx`) to utilize `TextButton` for all actions, ensuring uniform styling.

**Component Enhancement:**
- Updated `AppText` to accept a `className` prop, allowing integration with Tailwind CSS classes via `nativewind`.

**Testing:**
- Implemented a test suite for `TextButton`, checking rendering, press handling, disabled state, and style overrides.

## Evidence
<img width="206" height="622" alt="simulator_screenshot_D6C6ED3C-AB6F-41B0-97EC-A6A5D16E28BD" src="https://github.com/user-attachments/assets/13bc2e75-3e8f-4d41-9d64-d92c34121e4a" />