### PR TITLE
fix-459-reminders-not-sent

### DIFF
--- a/apps/mobile/screens/SignUp.tsx
+++ b/apps/mobile/screens/SignUp.tsx
@@ -4,6 +4,7 @@ import { View, TouchableOpacity, Image, ScrollView, Alert } from 'react-native';
 import logo from '../assets/logo.png';
 import { authService } from '../services/auth.service';
 import { storage } from '../utils/storage';
+import { notificationService } from '../services/notification.service';
 import { useTheme } from '../context/ThemeContext';
 import AppTextInput from '../components/UI/textInputWrapper';
 import AppText from '../components/UI/textWrapper';
@@ -45,6 +46,11 @@ export default function SignUpScreen({ navigation }: any) {
         //save token and data
         await storage.saveToken(response.data.token);
         await storage.saveUserData(response.data.user);
+
+        // Register for push notifications now that we're authenticated
+        notificationService
+          .setupNotifications()
+          .catch((err) => console.error('Failed to set up push notifications after signup:', err));
 
         Alert.alert('Success', 'Account created successfully!', [
           {

--- a/apps/mobile/screens/login.tsx
+++ b/apps/mobile/screens/login.tsx
@@ -4,6 +4,7 @@ import { View, Image, Alert } from 'react-native';
 import logo from '../assets/logo.png';
 import { authService } from '../services/auth.service';
 import { storage } from '../utils/storage';
+import { notificationService } from '../services/notification.service';
 import { useTheme } from '../context/ThemeContext';
 import AppTextInput from '../components/UI/textInputWrapper';
 import AppText from '../components/UI/textWrapper';
@@ -31,6 +32,11 @@ export default function LoginScreen({ navigation }: any) {
       if (response.status === 'success') {
         await storage.saveToken(response.data.token);
         await storage.saveUserData(response.data.user);
+
+        // Register for push notifications now that we're authenticated
+        notificationService
+          .setupNotifications()
+          .catch((err) => console.error('Failed to set up push notifications after login:', err));
 
         navigation.reset({
           index: 0,

--- a/apps/mobile/test/screens/SignUp.test.tsx
+++ b/apps/mobile/test/screens/SignUp.test.tsx
@@ -19,6 +19,13 @@ jest.mock('../../utils/storage', () => ({
   },
 }));
 
+const mockSetupNotifications = jest.fn();
+jest.mock('../../services/notification.service', () => ({
+  notificationService: {
+    setupNotifications: (...args: unknown[]) => mockSetupNotifications(...args),
+  },
+}));
+
 jest.mock('../../context/ThemeContext', () => ({
   useTheme: jest.fn(() => ({
     colors: {
@@ -37,6 +44,7 @@ const mockReset = jest.fn();
 describe('SignUpScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSetupNotifications.mockResolvedValue(null);
   });
 
   const setup = () => {
@@ -153,6 +161,75 @@ describe('SignUpScreen', () => {
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalledWith('Sign Up Failed', 'Email already in use');
+    });
+  });
+
+  it('calls setupNotifications after successful signup', async () => {
+    mockSetupNotifications.mockResolvedValue('ExponentPushToken[xxx]');
+    (authService.register as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: {
+        token: 'fake-token',
+        user: { id: 1, username: 'John' },
+      },
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Username'), 'John');
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'memantra');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'memantra');
+    fireEvent.press(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(mockSetupNotifications).toHaveBeenCalled();
+    });
+  });
+
+  it('does not call setupNotifications when signup fails', async () => {
+    (authService.register as jest.Mock).mockRejectedValue({
+      response: { data: { message: 'Email already in use' } },
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Username'), 'John');
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'memantra');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'memantra');
+    fireEvent.press(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Sign Up Failed', 'Email already in use');
+    });
+    expect(mockSetupNotifications).not.toHaveBeenCalled();
+  });
+
+  it('still shows success alert if setupNotifications fails', async () => {
+    mockSetupNotifications.mockRejectedValue(new Error('Notification setup failed'));
+    (authService.register as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: {
+        token: 'fake-token',
+        user: { id: 1, username: 'John' },
+      },
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Username'), 'John');
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'memantra');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'memantra');
+    fireEvent.press(getByText('Sign Up'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Success',
+        'Account created successfully!',
+        expect.any(Array),
+      );
     });
   });
 

--- a/apps/mobile/test/screens/login.test.tsx
+++ b/apps/mobile/test/screens/login.test.tsx
@@ -17,6 +17,13 @@ jest.mock('../../utils/storage', () => ({
   },
 }));
 
+const mockSetupNotifications = jest.fn();
+jest.mock('../../services/notification.service', () => ({
+  notificationService: {
+    setupNotifications: (...args: unknown[]) => mockSetupNotifications(...args),
+  },
+}));
+
 jest.mock('../../context/ThemeContext', () => ({
   useTheme: jest.fn(() => ({
     colors: {
@@ -39,6 +46,7 @@ const setup = () => render(<LoginScreen navigation={mockNavigation} />);
 describe('LoginScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSetupNotifications.mockResolvedValue(null);
   });
 
   const setup = () => {
@@ -109,6 +117,63 @@ describe('LoginScreen', () => {
 
     await waitFor(() => {
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('calls setupNotifications after successful login', async () => {
+    mockSetupNotifications.mockResolvedValue('ExponentPushToken[xxx]');
+    (authService.login as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { token: 'abc123', user: { id: 1, name: 'John' } },
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'memantra');
+    fireEvent.press(getByText('Login'));
+
+    await waitFor(() => {
+      expect(mockSetupNotifications).toHaveBeenCalled();
+    });
+  });
+
+  it('does not call setupNotifications when login fails', async () => {
+    (authService.login as jest.Mock).mockResolvedValue({
+      status: 'error',
+      message: 'Invalid credentials',
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'wrong');
+    fireEvent.press(getByText('Login'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Login Failed', 'Invalid credentials');
+    });
+    expect(mockSetupNotifications).not.toHaveBeenCalled();
+  });
+
+  it('still navigates to MainApp if setupNotifications fails', async () => {
+    mockSetupNotifications.mockRejectedValue(new Error('Notification setup failed'));
+    (authService.login as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { token: 'abc123', user: { id: 1, name: 'John' } },
+    });
+
+    const { getByPlaceholderText, getByText } = setup();
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'john@memantra.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'memantra');
+    fireEvent.press(getByText('Login'));
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'MainApp' }],
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Call setupNotifications() directly after successful login and signup

Needs to be confirmed with physical device since emulator bails out on device token registration.

## Linked Story
Closes #459 

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Other

## Evidence
- Screenshots / GIFs (if UI)
- Demo link (if applicable)

## Tests
- [x] Unit tests added/updated
- [ ] CI passing

## Notes
Co-authored-by: @username (if pair/mob programming)
