### PR TITLE
feat 472-Mantra Category Filter

### DIFF
--- a/apps/mobile/components/categoryFilterSheet.tsx
+++ b/apps/mobile/components/categoryFilterSheet.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  Modal,
+  Pressable,
+  View,
+  SectionList,
+  PanResponder,
+  Dimensions,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../context/ThemeContext';
+import AppText from './UI/textWrapper';
+import { Category } from '../services/category.service';
+
+type Props = {
+  readonly visible: boolean;
+  readonly categories: Category[];
+  readonly selectedCategoryIds: number[];
+  readonly onApply: (selectedIds: number[]) => void;
+  readonly onClose: () => void;
+  readonly loading?: boolean;
+};
+
+const { height: H } = Dimensions.get('window');
+const MAX_H = H * 0.7;
+const OFFSCREEN = H;
+const THRESHOLD = 140;
+
+// parent category labels
+const SECTION_LABELS: Record<string, string> = {
+  essential: 'Essentials',
+  goal: 'Goal-Based Categories',
+  mood: 'Mood / Emotion-Based',
+  scenario: 'Life Scenarios',
+  time: 'Times of Day / Year',
+  theme: 'Values / Inspirational Themes',
+};
+
+const SECTION_ORDER = ['essential', 'goal', 'mood', 'scenario', 'time', 'theme'];
+
+export default function CategoryFilterSheet({
+  visible,
+  categories,
+  selectedCategoryIds,
+  onApply,
+  onClose,
+  loading = false,
+}: Props) {
+  const { colors } = useTheme();
+  const slide = useRef(new Animated.Value(0)).current;
+  const dragY = useRef(new Animated.Value(0)).current;
+  const [localSelected, setLocalSelected] = useState<number[]>(selectedCategoryIds);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const closeSheet = () => {
+    setIsDragging(false);
+    Animated.parallel([
+      Animated.timing(dragY, { toValue: OFFSCREEN, duration: 220, useNativeDriver: true }),
+      Animated.timing(slide, { toValue: 0, duration: 220, useNativeDriver: true }),
+    ]).start(({ finished }) => finished && (dragY.setValue(0), onClose()));
+  };
+
+  const snapBack = () => {
+    setIsDragging(false);
+    Animated.spring(dragY, { toValue: 0, useNativeDriver: true, bounciness: 0, speed: 18 }).start();
+  };
+
+  useEffect(() => {
+    if (visible) {
+      setLocalSelected(selectedCategoryIds);
+      dragY.setValue(0);
+      Animated.timing(slide, { toValue: 1, duration: 260, useNativeDriver: true }).start();
+    } else {
+      dragY.setValue(0);
+      slide.setValue(0);
+      setIsDragging(false);
+    }
+  }, [visible]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_e, g) => Math.abs(g.dy) > 4 && Math.abs(g.dy) > Math.abs(g.dx),
+      onPanResponderGrant: () => setIsDragging(true),
+      onPanResponderMove: (_e, g) => dragY.setValue(Math.max(-18, g.dy)),
+      onPanResponderRelease: (_e, g) =>
+        g.dy > THRESHOLD || g.vy > 1.2 ? closeSheet() : snapBack(),
+      onPanResponderTerminate: snapBack,
+    }),
+  ).current;
+
+  const toggleCategory = (categoryId: number) => {
+    setLocalSelected((prev) =>
+      prev.includes(categoryId) ? prev.filter((id) => id !== categoryId) : [...prev, categoryId],
+    );
+  };
+
+  const handleApply = () => {
+    onApply(localSelected);
+    closeSheet();
+  };
+
+  const handleClear = () => {
+    setLocalSelected([]);
+  };
+
+  // group categories by parent_id and category_type for section list
+  const sections = useMemo(() => {
+    const topLevel = categories.filter((c) => !c.parent_id);
+    const grouped: Record<string, Category[]> = {};
+    for (const cat of topLevel) {
+      const type = cat.category_type || 'other';
+      if (!grouped[type]) grouped[type] = [];
+      grouped[type].push(cat);
+    }
+    return SECTION_ORDER.filter((type) => grouped[type]?.length).map((type) => ({
+      title: SECTION_LABELS[type] || type,
+      data: grouped[type],
+    }));
+  }, [categories]);
+
+  const backdropOpacity = slide.interpolate({ inputRange: [0, 1], outputRange: [0, 0.5] });
+  const translateY = Animated.add(
+    slide.interpolate({ inputRange: [0, 1], outputRange: [OFFSCREEN, 0] }),
+    dragY,
+  );
+
+  return (
+    <Modal visible={visible} transparent animationType="none" onRequestClose={closeSheet}>
+      <View className="flex-1" testID="category-filter-sheet">
+        <Pressable className="absolute inset-0" onPress={closeSheet}>
+          <Animated.View
+            className="flex-1"
+            style={{ backgroundColor: '#000', opacity: backdropOpacity }}
+          />
+        </Pressable>
+
+        <Animated.View
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            maxHeight: MAX_H,
+            backgroundColor: colors.primary,
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+            transform: [{ translateY }],
+            overflow: 'hidden',
+          }}
+        >
+          <View {...panResponder.panHandlers} className="items-center pt-3 pb-2">
+            <View
+              style={{
+                width: 40,
+                height: 5,
+                borderRadius: 3,
+                backgroundColor: colors.secondary,
+                opacity: 0.5,
+              }}
+            />
+          </View>
+
+          <View className="flex-row justify-between items-center px-5 pb-3">
+            <AppText className="text-lg font-bold" style={{ color: colors.text }}>
+              Filter by Category
+            </AppText>
+            <View className="flex-row items-center" style={{ gap: 12 }}>
+              {localSelected.length > 0 && (
+                <TouchableOpacity onPress={handleClear} testID="clear-filter-btn">
+                  <AppText className="text-sm" style={{ color: colors.secondary }}>
+                    Clear
+                  </AppText>
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity
+                onPress={handleApply}
+                testID="apply-filter-btn"
+                className="rounded-full px-4 py-2"
+                style={{ backgroundColor: colors.secondary }}
+              >
+                <AppText className="text-sm font-semibold" style={{ color: colors.primary }}>
+                  Apply{localSelected.length > 0 ? ` (${localSelected.length})` : ''}
+                </AppText>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {loading ? (
+            <View className="flex-1 justify-center items-center py-8">
+              <ActivityIndicator size="large" color={colors.secondary} />
+            </View>
+          ) : sections.length === 0 ? (
+            <View className="flex-1 justify-center items-center py-8">
+              <AppText className="text-base" style={{ color: colors.text }}>
+                No categories available
+              </AppText>
+            </View>
+          ) : (
+            <SectionList
+              sections={sections}
+              keyExtractor={(item) => item.category_id.toString()}
+              contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 30 }}
+              showsVerticalScrollIndicator={false}
+              stickySectionHeadersEnabled={false}
+              renderSectionHeader={({ section: { title } }) => (
+                <View
+                  className="pt-4 pb-2"
+                  style={{ borderBottomWidth: 1, borderBottomColor: `${colors.secondary}30` }}
+                >
+                  <AppText
+                    className="text-xs font-bold tracking-wide"
+                    style={{
+                      color: colors.secondary,
+                      textTransform: 'uppercase',
+                      letterSpacing: 1,
+                    }}
+                  >
+                    {title}
+                  </AppText>
+                </View>
+              )}
+              renderItem={({ item }) => {
+                const isSelected = localSelected.includes(item.category_id);
+                return (
+                  <TouchableOpacity
+                    testID={`category-filter-item-${item.category_id}`}
+                    onPress={() => toggleCategory(item.category_id)}
+                    className="flex-row items-center py-3"
+                    style={{
+                      borderBottomWidth: 0.5,
+                      borderBottomColor: `${colors.text}20`,
+                    }}
+                  >
+                    <View
+                      className="rounded-full items-center justify-center mr-3"
+                      style={{
+                        width: 28,
+                        height: 28,
+                        borderWidth: 2,
+                        borderColor: isSelected ? colors.secondary : `${colors.text}40`,
+                        backgroundColor: isSelected ? colors.secondary : 'transparent',
+                      }}
+                    >
+                      {isSelected && <Ionicons name="checkmark" size={18} color={colors.primary} />}
+                    </View>
+                    <View className="flex-1">
+                      <AppText
+                        className="text-base font-medium"
+                        style={{ color: isSelected ? colors.secondary : colors.text }}
+                      >
+                        {item.name}
+                      </AppText>
+                      {item.description ? (
+                        <AppText
+                          className="text-xs mt-0.5"
+                          style={{ color: `${colors.text}80` }}
+                          numberOfLines={1}
+                        >
+                          {item.description}
+                        </AppText>
+                      ) : null}
+                    </View>
+                  </TouchableOpacity>
+                );
+              }}
+            />
+          )}
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/components/categoryFilterSheet.tsx
+++ b/apps/mobile/components/categoryFilterSheet.tsx
@@ -53,10 +53,10 @@ export default function CategoryFilterSheet({
   const slide = useRef(new Animated.Value(0)).current;
   const dragY = useRef(new Animated.Value(0)).current;
   const [localSelected, setLocalSelected] = useState<number[]>(selectedCategoryIds);
-  const [, setIsDragging] = useState(false);
+  const isDraggingRef = useRef(false);
 
   const closeSheet = () => {
-    setIsDragging(false);
+    isDraggingRef.current = false;
     Animated.parallel([
       Animated.timing(dragY, { toValue: OFFSCREEN, duration: 220, useNativeDriver: true }),
       Animated.timing(slide, { toValue: 0, duration: 220, useNativeDriver: true }),
@@ -64,7 +64,7 @@ export default function CategoryFilterSheet({
   };
 
   const snapBack = () => {
-    setIsDragging(false);
+    isDraggingRef.current = false;
     Animated.spring(dragY, { toValue: 0, useNativeDriver: true, bounciness: 0, speed: 18 }).start();
   };
 
@@ -76,7 +76,7 @@ export default function CategoryFilterSheet({
     } else {
       dragY.setValue(0);
       slide.setValue(0);
-      setIsDragging(false);
+      isDraggingRef.current = false;
     }
   }, [visible]);
 
@@ -84,7 +84,9 @@ export default function CategoryFilterSheet({
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: (_e, g) => Math.abs(g.dy) > 4 && Math.abs(g.dy) > Math.abs(g.dx),
-      onPanResponderGrant: () => setIsDragging(true),
+      onPanResponderGrant: () => {
+        isDraggingRef.current = true;
+      },
       onPanResponderMove: (_e, g) => dragY.setValue(Math.max(-18, g.dy)),
       onPanResponderRelease: (_e, g) =>
         g.dy > THRESHOLD || g.vy > 1.2 ? closeSheet() : snapBack(),
@@ -126,6 +128,87 @@ export default function CategoryFilterSheet({
   const translateY = Animated.add(
     slide.interpolate({ inputRange: [0, 1], outputRange: [OFFSCREEN, 0] }),
     dragY,
+  );
+
+  const contentElement = loading ? (
+    <View className="flex-1 justify-center items-center py-8">
+      <ActivityIndicator size="large" color={colors.secondary} />
+    </View>
+  ) : sections.length === 0 ? (
+    <View className="flex-1 justify-center items-center py-8">
+      <AppText className="text-base" style={{ color: colors.text }}>
+        No categories available
+      </AppText>
+    </View>
+  ) : (
+    <SectionList
+      sections={sections}
+      keyExtractor={(item) => item.category_id.toString()}
+      contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 30 }}
+      showsVerticalScrollIndicator={false}
+      stickySectionHeadersEnabled={false}
+      renderSectionHeader={({ section: { title } }) => (
+        <View
+          className="pt-4 pb-2"
+          style={{ borderBottomWidth: 1, borderBottomColor: `${colors.secondary}30` }}
+        >
+          <AppText
+            className="text-xs font-bold tracking-wide"
+            style={{
+              color: colors.secondary,
+              textTransform: 'uppercase',
+              letterSpacing: 1,
+            }}
+          >
+            {title}
+          </AppText>
+        </View>
+      )}
+      renderItem={({ item }) => {
+        const isSelected = localSelected.includes(item.category_id);
+        return (
+          <TouchableOpacity
+            testID={`category-filter-item-${item.category_id}`}
+            onPress={() => toggleCategory(item.category_id)}
+            className="flex-row items-center py-3"
+            style={{
+              borderBottomWidth: 0.5,
+              borderBottomColor: `${colors.text}20`,
+            }}
+          >
+            <View
+              className="rounded-full items-center justify-center mr-3"
+              style={{
+                width: 28,
+                height: 28,
+                borderWidth: 2,
+                borderColor: isSelected ? colors.secondary : `${colors.text}40`,
+                backgroundColor: isSelected ? colors.secondary : 'transparent',
+              }}
+            >
+              {isSelected && <Ionicons name="checkmark" size={18} color={colors.primary} />}
+            </View>
+            <View className="flex-1">
+              <AppText
+                className="text-base font-medium"
+                style={{ color: isSelected ? colors.secondary : colors.text }}
+              >
+                {item.name}
+              </AppText>
+              {item.description ? (
+                <AppText
+                  className="text-xs mt-0.5"
+                  style={{ color: `${colors.text}80` }}
+                  numberOfLines={1}
+                >
+                  {item.description}
+                </AppText>
+              ) : null}
+            </View>
+          </TouchableOpacity>
+        );
+      }}
+    />
   );
 
   return (
@@ -189,86 +272,7 @@ export default function CategoryFilterSheet({
             </View>
           </View>
 
-          {loading ? (
-            <View className="flex-1 justify-center items-center py-8">
-              <ActivityIndicator size="large" color={colors.secondary} />
-            </View>
-          ) : sections.length === 0 ? (
-            <View className="flex-1 justify-center items-center py-8">
-              <AppText className="text-base" style={{ color: colors.text }}>
-                No categories available
-              </AppText>
-            </View>
-          ) : (
-            <SectionList
-              sections={sections}
-              keyExtractor={(item) => item.category_id.toString()}
-              contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 30 }}
-              showsVerticalScrollIndicator={false}
-              stickySectionHeadersEnabled={false}
-              renderSectionHeader={({ section: { title } }) => (
-                <View
-                  className="pt-4 pb-2"
-                  style={{ borderBottomWidth: 1, borderBottomColor: `${colors.secondary}30` }}
-                >
-                  <AppText
-                    className="text-xs font-bold tracking-wide"
-                    style={{
-                      color: colors.secondary,
-                      textTransform: 'uppercase',
-                      letterSpacing: 1,
-                    }}
-                  >
-                    {title}
-                  </AppText>
-                </View>
-              )}
-              renderItem={({ item }) => {
-                const isSelected = localSelected.includes(item.category_id);
-                return (
-                  <TouchableOpacity
-                    testID={`category-filter-item-${item.category_id}`}
-                    onPress={() => toggleCategory(item.category_id)}
-                    className="flex-row items-center py-3"
-                    style={{
-                      borderBottomWidth: 0.5,
-                      borderBottomColor: `${colors.text}20`,
-                    }}
-                  >
-                    <View
-                      className="rounded-full items-center justify-center mr-3"
-                      style={{
-                        width: 28,
-                        height: 28,
-                        borderWidth: 2,
-                        borderColor: isSelected ? colors.secondary : `${colors.text}40`,
-                        backgroundColor: isSelected ? colors.secondary : 'transparent',
-                      }}
-                    >
-                      {isSelected && <Ionicons name="checkmark" size={18} color={colors.primary} />}
-                    </View>
-                    <View className="flex-1">
-                      <AppText
-                        className="text-base font-medium"
-                        style={{ color: isSelected ? colors.secondary : colors.text }}
-                      >
-                        {item.name}
-                      </AppText>
-                      {item.description ? (
-                        <AppText
-                          className="text-xs mt-0.5"
-                          style={{ color: `${colors.text}80` }}
-                          numberOfLines={1}
-                        >
-                          {item.description}
-                        </AppText>
-                      ) : null}
-                    </View>
-                  </TouchableOpacity>
-                );
-              }}
-            />
-          )}
+          {contentElement}
         </Animated.View>
       </View>
     </Modal>

--- a/apps/mobile/components/categoryFilterSheet.tsx
+++ b/apps/mobile/components/categoryFilterSheet.tsx
@@ -53,7 +53,7 @@ export default function CategoryFilterSheet({
   const slide = useRef(new Animated.Value(0)).current;
   const dragY = useRef(new Animated.Value(0)).current;
   const [localSelected, setLocalSelected] = useState<number[]>(selectedCategoryIds);
-  const [isDragging, setIsDragging] = useState(false);
+  const [, setIsDragging] = useState(false);
 
   const closeSheet = () => {
     setIsDragging(false);

--- a/apps/mobile/screens/homeScreen.tsx
+++ b/apps/mobile/screens/homeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   FlatList,
@@ -12,6 +12,7 @@ import { Ionicons } from '@expo/vector-icons';
 import MantraCarousel from '../components/carousel';
 import { mantraService, Mantra } from '../services/mantra.service';
 import { collectionService, Collection } from '../services/collection.service';
+import { categoryService, Category } from '../services/category.service';
 import { ratingService } from '../services/rating.service';
 import { storage } from '../utils/storage';
 import SearchBar from '../components/UI/searchBar';
@@ -22,6 +23,7 @@ import { useTheme } from '../context/ThemeContext';
 import { useSavedMantras } from '../context/SavedContext';
 import SavedPopupBar from '../components/UI/savedPopupBar';
 import CollectionsSheet from '../components/collectionsSheet';
+import CategoryFilterSheet from '../components/categoryFilterSheet';
 import { useReminders } from '../hooks/useReminders';
 import { engagementService } from '../services/engagement.service';
 
@@ -36,6 +38,12 @@ export default function HomeScreen({ navigation, route }: any) {
   const [collections, setCollections] = useState<Collection[]>([]);
   const [currentMantraId, setCurrentMantraId] = useState<number | null>(null);
 
+  // Category filter state
+  const [allCategories, setAllCategories] = useState<Category[]>([]);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
+  const [showCategoryFilter, setShowCategoryFilter] = useState(false);
+  const [categoriesLoading, setCategoriesLoading] = useState(false);
+
   //for smoother animations
   const [initialIndex, setInitialIndex] = useState(0);
   const [readyToShowFeed, setReadyToShowFeed] = useState(false);
@@ -49,6 +57,7 @@ export default function HomeScreen({ navigation, route }: any) {
   useEffect(() => {
     loadMantras();
     loadCollections();
+    loadCategories();
   }, []);
 
   const loadMantras = async () => {
@@ -107,6 +116,29 @@ export default function HomeScreen({ navigation, route }: any) {
     // clear param so it doesn't keep jumping
     navigation.setParams({ returnToMantraId: undefined });
   }, [loading, feedData, route?.params?.returnToMantraId]);
+
+  const loadCategories = async () => {
+    try {
+      setCategoriesLoading(true);
+      const token = (await storage.getToken()) || 'mock-token';
+      const response = await categoryService.getAllCategories(token);
+      if (response.status === 'success' && response.data) {
+        setAllCategories(response.data.categories);
+      }
+    } catch (err) {
+      console.error('Error fetching categories:', err);
+    } finally {
+      setCategoriesLoading(false);
+    }
+  };
+
+  // feed based on the categories selected in the filter
+  const filteredFeedData = useMemo(() => {
+    if (selectedCategoryIds.length === 0) return feedData;
+    return feedData.filter((mantra) =>
+      mantra.categories?.some((c) => selectedCategoryIds.includes(c.category_id)),
+    );
+  }, [feedData, selectedCategoryIds]);
 
   const loadCollections = async () => {
     try {
@@ -276,6 +308,10 @@ export default function HomeScreen({ navigation, route }: any) {
 
   const handleSearch = (query: string) => console.log('Searching for:', query);
 
+  const handleApplyCategoryFilter = (selected: number[]) => {
+    setSelectedCategoryIds(selected);
+  };
+
   const handleUserPress = () => {
     Alert.alert(
       'Account',
@@ -330,12 +366,34 @@ export default function HomeScreen({ navigation, route }: any) {
         </TouchableOpacity>
       </View>
     );
+  } else if (filteredFeedData.length === 0) {
+    content = (
+      <View
+        className="flex-1 justify-center items-center px-6"
+        style={{ backgroundColor: colors.primary }}
+      >
+        <Ionicons name="funnel-outline" size={64} color={colors.secondary} />
+        <AppText className="mt-4 text-lg font-semibold text-center" style={{ color: colors.text }}>
+          No mantras match the selected categories
+        </AppText>
+        <TouchableOpacity
+          className="rounded-full px-6 py-3 mt-6"
+          onPress={() => setSelectedCategoryIds([])}
+          accessibilityRole="button"
+          style={{ backgroundColor: colors.secondary }}
+        >
+          <AppText className="font-semibold text-base" style={{ color: colors.primary }}>
+            Clear Filters
+          </AppText>
+        </TouchableOpacity>
+      </View>
+    );
   } else {
     content = (
       <FlatList
-        key={`feed-${initialIndex}`} // ✅ remount so initialScrollIndex is applied when it changes
+        key={`feed-${initialIndex}-${selectedCategoryIds.join(',')}`}
         ref={listRef}
-        data={feedData}
+        data={filteredFeedData}
         initialScrollIndex={initialIndex} // ✅ no flash to first item
         renderItem={({ item }) => (
           <MantraCarousel
@@ -378,7 +436,45 @@ export default function HomeScreen({ navigation, route }: any) {
   return (
     <View className="flex-1" style={{ backgroundColor: colors.primary }}>
       <View className="absolute top-5 left-0 right-0 z-10 flex-row justify-between items-center px-6 pt-14 pb-4">
-        <SearchBar onSearch={handleSearch} placeholder="Search mantras..." />
+        <View className="flex-row items-center" style={{ gap: 8 }}>
+          <SearchBar onSearch={handleSearch} placeholder="Search mantras..." />
+          <TouchableOpacity
+            testID="category-filter-btn"
+            activeOpacity={0.7}
+            onPress={() => setShowCategoryFilter(true)}
+            className="items-center justify-center"
+          >
+            <View
+              className="rounded-full items-center justify-center"
+              style={{
+                width: 48,
+                height: 48,
+                backgroundColor:
+                  selectedCategoryIds.length > 0 ? colors.secondary : colors.secondary,
+              }}
+            >
+              <Ionicons
+                name={selectedCategoryIds.length > 0 ? 'funnel' : 'funnel-outline'}
+                size={24}
+                color={colors.primaryDark}
+              />
+            </View>
+            {selectedCategoryIds.length > 0 && (
+              <View
+                className="absolute -top-1 -right-1 rounded-full items-center justify-center"
+                style={{
+                  width: 20,
+                  height: 20,
+                  backgroundColor: colors.primaryDark,
+                }}
+              >
+                <AppText className="text-xs font-bold" style={{ color: colors.secondary }}>
+                  {selectedCategoryIds.length}
+                </AppText>
+              </View>
+            )}
+          </TouchableOpacity>
+        </View>
         <IconButton type="profile" onPress={handleUserPress} testID="profile-btn" />
       </View>
 
@@ -407,6 +503,15 @@ export default function HomeScreen({ navigation, route }: any) {
         onSelectCollection={handleSelectCollection}
         onCreateCollection={handleCreateCollection}
         onRefresh={loadCollections}
+      />
+
+      <CategoryFilterSheet
+        visible={showCategoryFilter}
+        categories={allCategories}
+        selectedCategoryIds={selectedCategoryIds}
+        onApply={handleApplyCategoryFilter}
+        onClose={() => setShowCategoryFilter(false)}
+        loading={categoriesLoading}
       />
 
       {!!collectionToast && (

--- a/apps/mobile/screens/homeScreen.tsx
+++ b/apps/mobile/screens/homeScreen.tsx
@@ -449,8 +449,7 @@ export default function HomeScreen({ navigation, route }: any) {
               style={{
                 width: 48,
                 height: 48,
-                backgroundColor:
-                  selectedCategoryIds.length > 0 ? colors.secondary : colors.secondary,
+                backgroundColor: colors.secondary,
               }}
             >
               <Ionicons

--- a/apps/mobile/test/components/categoryFilterSheet.test.tsx
+++ b/apps/mobile/test/components/categoryFilterSheet.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+import CategoryFilterSheet from '../../components/categoryFilterSheet';
+import { Category } from '../../services/category.service';
+
+// Mock
+jest.spyOn(Animated, 'timing').mockImplementation((value: any, config: any) => ({
+  start: jest.fn((callback?: (result: { finished: boolean }) => void) => {
+    if (callback) {
+      callback({ finished: true });
+    }
+  }),
+  stop: jest.fn(),
+  reset: jest.fn(),
+}));
+
+jest.spyOn(Animated, 'spring').mockImplementation((value: any, config: any) => ({
+  start: jest.fn((callback?: (result: { finished: boolean }) => void) => {
+    if (callback) {
+      callback({ finished: true });
+    }
+  }),
+  stop: jest.fn(),
+  reset: jest.fn(),
+}));
+
+describe('CategoryFilterSheet', () => {
+  const mockCategories: Category[] = [
+    {
+      category_id: 1,
+      name: 'Mind & Emotional Health',
+      description: 'Mantras for mental well-being',
+      category_type: 'essential',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 2,
+      name: 'Physical Health & Energy',
+      description: 'Mantras for physical vitality',
+      category_type: 'essential',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 3,
+      name: 'Stress Relief / Calm',
+      description: 'Mantras to reduce stress',
+      category_type: 'essential',
+      parent_id: 1,
+      is_active: true,
+    },
+    {
+      category_id: 20,
+      name: 'Boost Confidence & Courage',
+      description: 'Mantras to build confidence',
+      category_type: 'goal',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 30,
+      name: 'Calm / Relaxed',
+      description: 'When you feel calm',
+      category_type: 'mood',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 40,
+      name: 'Work Challenges & Deadlines',
+      description: 'Mantras for work pressure',
+      category_type: 'scenario',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 50,
+      name: 'Morning Motivation',
+      description: 'Mantras to start the day',
+      category_type: 'time',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 60,
+      name: 'Courage & Confidence',
+      description: 'Mantras for bravery',
+      category_type: 'theme',
+      parent_id: null,
+      is_active: true,
+    },
+  ];
+
+  const mockOnApply = jest.fn();
+  const mockOnClose = jest.fn();
+
+  const defaultProps = {
+    visible: true,
+    categories: mockCategories,
+    selectedCategoryIds: [] as number[],
+    onApply: mockOnApply,
+    onClose: mockOnClose,
+    loading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders when visible is true', () => {
+    const { getByText, getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    expect(getByTestId('category-filter-sheet')).toBeTruthy();
+    expect(getByText('Filter by Category')).toBeTruthy();
+    expect(getByTestId('apply-filter-btn')).toBeTruthy();
+  });
+
+  it('does not render content when visible is false', () => {
+    const { queryByText } = render(<CategoryFilterSheet {...defaultProps} visible={false} />);
+
+    expect(queryByText('Filter by Category')).toBeNull();
+  });
+
+  it('displays section headers for category types that have data', () => {
+    const { getByText } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    expect(getByText('Essentials')).toBeTruthy();
+    expect(getByText('Goal-Based Categories')).toBeTruthy();
+    expect(getByText('Mood / Emotion-Based')).toBeTruthy();
+  });
+
+  it('displays top-level categories but not subcategories', () => {
+    const { getByText, queryByText } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    expect(getByText('Mind & Emotional Health')).toBeTruthy();
+    expect(getByText('Physical Health & Energy')).toBeTruthy();
+    expect(getByText('Boost Confidence & Courage')).toBeTruthy();
+
+    expect(queryByText('Stress Relief / Calm')).toBeNull();
+  });
+
+  it('displays category descriptions', () => {
+    const { getByText } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    expect(getByText('Mantras for mental well-being')).toBeTruthy();
+    expect(getByText('Mantras for physical vitality')).toBeTruthy();
+  });
+
+  it('toggles category selection when pressed', () => {
+    const { getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    fireEvent.press(getByTestId('category-filter-item-1'));
+
+    expect(getByTestId('apply-filter-btn')).toBeTruthy();
+  });
+
+  it('selects and deselects categories', () => {
+    const { getByTestId, getByText } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    fireEvent.press(getByTestId('category-filter-item-1'));
+
+    expect(getByText('Apply (1)')).toBeTruthy();
+
+    fireEvent.press(getByTestId('category-filter-item-20'));
+    expect(getByText('Apply (2)')).toBeTruthy();
+
+    fireEvent.press(getByTestId('category-filter-item-1'));
+    expect(getByText('Apply (1)')).toBeTruthy();
+  });
+
+  it('calls onApply with selected category IDs when Apply is pressed', () => {
+    const { getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    fireEvent.press(getByTestId('category-filter-item-1'));
+    fireEvent.press(getByTestId('category-filter-item-30'));
+
+    fireEvent.press(getByTestId('apply-filter-btn'));
+
+    expect(mockOnApply).toHaveBeenCalledWith([1, 30]);
+  });
+
+  it('calls onApply with empty array when Apply is pressed with no selection', () => {
+    const { getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    fireEvent.press(getByTestId('apply-filter-btn'));
+
+    expect(mockOnApply).toHaveBeenCalledWith([]);
+  });
+
+  it('shows Clear button when categories are selected and clears on press', () => {
+    const { getByTestId, getByText, queryByTestId } = render(
+      <CategoryFilterSheet {...defaultProps} />,
+    );
+
+    expect(queryByTestId('clear-filter-btn')).toBeNull();
+
+    fireEvent.press(getByTestId('category-filter-item-1'));
+
+    expect(getByTestId('clear-filter-btn')).toBeTruthy();
+
+    fireEvent.press(getByTestId('clear-filter-btn'));
+
+    expect(getByText('Apply')).toBeTruthy();
+  });
+
+  it('initializes with pre-selected category IDs', () => {
+    const { getByText } = render(
+      <CategoryFilterSheet {...defaultProps} selectedCategoryIds={[1, 20]} />,
+    );
+
+    expect(getByText('Apply (2)')).toBeTruthy();
+  });
+
+  it('shows loading state when loading is true', () => {
+    const { getByTestId, queryByText } = render(
+      <CategoryFilterSheet {...defaultProps} loading={true} />,
+    );
+
+    expect(getByTestId('category-filter-sheet')).toBeTruthy();
+    expect(queryByText('ESSENTIALS')).toBeNull();
+  });
+
+  it('shows empty state when no categories are available', () => {
+    const { getByText } = render(<CategoryFilterSheet {...defaultProps} categories={[]} />);
+
+    expect(getByText('No categories available')).toBeTruthy();
+  });
+
+  it('closes sheet when backdrop is pressed', () => {
+    const { getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    const sheet = getByTestId('category-filter-sheet');
+    expect(sheet).toBeTruthy();
+  });
+
+  it('resets local selection when sheet becomes visible again', () => {
+    const { rerender, getByText, getByTestId } = render(
+      <CategoryFilterSheet {...defaultProps} selectedCategoryIds={[1]} />,
+    );
+
+    expect(getByText('Apply (1)')).toBeTruthy();
+
+    fireEvent.press(getByTestId('category-filter-item-20'));
+    expect(getByText('Apply (2)')).toBeTruthy();
+
+    rerender(<CategoryFilterSheet {...defaultProps} selectedCategoryIds={[1]} visible={false} />);
+    rerender(<CategoryFilterSheet {...defaultProps} selectedCategoryIds={[1]} visible={true} />);
+
+    expect(getByText('Apply (1)')).toBeTruthy();
+  });
+
+  it('handles categories without description', () => {
+    const categoriesWithoutDesc: Category[] = [
+      {
+        category_id: 100,
+        name: 'No Description Category',
+        category_type: 'essential',
+        parent_id: null,
+        is_active: true,
+      },
+    ];
+
+    const { getByText, queryByTestId } = render(
+      <CategoryFilterSheet {...defaultProps} categories={categoriesWithoutDesc} />,
+    );
+
+    expect(getByText('No Description Category')).toBeTruthy();
+  });
+
+  it('handles categories with unknown category_type', () => {
+    const categoriesUnknownType: Category[] = [
+      {
+        category_id: 200,
+        name: 'Unknown Type Category',
+        description: 'A category with unknown type',
+        category_type: undefined,
+        parent_id: null,
+        is_active: true,
+      },
+    ];
+
+    const { queryByText } = render(
+      <CategoryFilterSheet {...defaultProps} categories={categoriesUnknownType} />,
+    );
+
+    expect(queryByText('Unknown Type Category')).toBeNull();
+  });
+
+  it('shows Apply without count when no categories selected', () => {
+    const { getByText } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    expect(getByText('Apply')).toBeTruthy();
+  });
+
+  it('calls onClose after closing animation completes', () => {
+    const { getByTestId } = render(<CategoryFilterSheet {...defaultProps} />);
+
+    fireEvent.press(getByTestId('apply-filter-btn'));
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/test/screens/homeScreen.test.tsx
+++ b/apps/mobile/test/screens/homeScreen.test.tsx
@@ -3,7 +3,9 @@ import { Alert } from 'react-native';
 import HomeScreen from '../../screens/homeScreen';
 import { mantraService } from '../../services/mantra.service';
 import { collectionService } from '../../services/collection.service';
+import { categoryService } from '../../services/category.service';
 import { reminderService } from '../../services/reminder.service';
+import { ratingService } from '../../services/rating.service';
 import { storage } from '../../utils/storage';
 import { SavedProvider } from '../../context/SavedContext';
 import { engagementService } from '../../services/engagement.service';
@@ -12,7 +14,7 @@ jest.mock('../../components/carousel', () => {
   const React = jest.requireActual('react');
   const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
 
-  return function MockCarousel({ item, onLike, onSave, onReminder }: any) {
+  return function MockCarousel({ item, onLike, onSave, onReminder, onShare, onJournal }: any) {
     return (
       <View>
         <Text>{item.title}</Text>
@@ -30,22 +32,49 @@ jest.mock('../../components/carousel', () => {
             <Text>Reminder</Text>
           </TouchableOpacity>
         )}
+        {onShare && (
+          <TouchableOpacity
+            testID={`share-${item.mantra_id}`}
+            onPress={() => onShare(item.mantra_id)}
+          >
+            <Text>Share</Text>
+          </TouchableOpacity>
+        )}
+        {onJournal && (
+          <TouchableOpacity
+            testID={`journal-${item.mantra_id}`}
+            onPress={() => onJournal(item.mantra_id, item.title)}
+          >
+            <Text>Journal</Text>
+          </TouchableOpacity>
+        )}
       </View>
     );
   };
 });
 
+jest.mock('../../services/rating.service', () => ({
+  ratingService: {
+    rateMantra: jest.fn(),
+  },
+}));
+
 jest.mock('../../components/UI/savedPopupBar', () => {
   const React = jest.requireActual('react');
   const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
 
-  return function MockSavedPopupBar({ visible, onHide, onPressCollections }: any) {
+  return function MockSavedPopupBar({ visible, onHide, onPressCollections, onRate }: any) {
     if (!visible) return null;
     return (
       <View testID="saved-popup-bar">
         <TouchableOpacity testID="close-popup" onPress={onHide}>
           <Text>Close</Text>
         </TouchableOpacity>
+        {onRate && (
+          <TouchableOpacity testID="rate-mantra" onPress={() => onRate(5)}>
+            <Text>Rate</Text>
+          </TouchableOpacity>
+        )}
         <TouchableOpacity testID="open-collections" onPress={onPressCollections}>
           <Text>Add to Collection</Text>
         </TouchableOpacity>
@@ -100,6 +129,49 @@ jest.mock('../../components/collectionsSheet', () => {
   };
 });
 
+jest.mock('../../components/categoryFilterSheet', () => {
+  const React = jest.requireActual('react');
+  const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+
+  return function MockCategoryFilterSheet({
+    visible,
+    categories,
+    selectedCategoryIds,
+    onApply,
+    onClose,
+    loading,
+  }: any) {
+    if (!visible) return null;
+    return (
+      <View testID="category-filter-sheet">
+        <Text>Filter by Category</Text>
+        {loading && <Text>Loading categories...</Text>}
+        {categories.map((cat: any) => (
+          <TouchableOpacity
+            key={cat.category_id}
+            testID={`filter-cat-${cat.category_id}`}
+            onPress={() => {
+              const isSelected = selectedCategoryIds.includes(cat.category_id);
+              const newSelected = isSelected
+                ? selectedCategoryIds.filter((id: number) => id !== cat.category_id)
+                : [...selectedCategoryIds, cat.category_id];
+              onApply(newSelected);
+            }}
+          >
+            <Text>{cat.name}</Text>
+          </TouchableOpacity>
+        ))}
+        <TouchableOpacity testID="apply-filter" onPress={() => onApply(selectedCategoryIds)}>
+          <Text>Apply</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="close-filter" onPress={onClose}>
+          <Text>Close Filter</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+});
+
 jest.mock('@react-navigation/native', () => {
   const React = jest.requireActual('react');
   return {
@@ -127,6 +199,12 @@ jest.mock('../../services/collection.service', () => ({
     getUserCollections: jest.fn(),
     addMantraToCollection: jest.fn(),
     createCollection: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/category.service', () => ({
+  categoryService: {
+    getAllCategories: jest.fn(),
   },
 }));
 
@@ -172,6 +250,10 @@ describe('HomeScreen - Full Coverage', () => {
     (collectionService.getUserCollections as jest.Mock).mockResolvedValue({
       status: 'success',
       data: { collections: [] },
+    });
+    (categoryService.getAllCategories as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { categories: [] },
     });
   });
 
@@ -1638,6 +1720,10 @@ describe('HomeScreen - engagement tracking', () => {
       status: 'success',
       data: { collections: [] },
     });
+    (categoryService.getAllCategories as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { categories: [] },
+    });
     (reminderService.getReminders as jest.Mock).mockResolvedValue({
       status: 'success',
       data: { reminders: [] },
@@ -1708,4 +1794,549 @@ describe('HomeScreen - engagement tracking', () => {
       { timeout: 10000 },
     );
   }, 20000);
+});
+
+describe('HomeScreen - category filter', () => {
+  const mockNavigate = jest.fn();
+  const mockReset = jest.fn();
+
+  const mockCategories = [
+    {
+      category_id: 1,
+      name: 'Mind & Emotional Health',
+      description: 'Mantras for mental well-being',
+      category_type: 'essential',
+      parent_id: null,
+      is_active: true,
+    },
+    {
+      category_id: 20,
+      name: 'Boost Confidence',
+      description: 'Mantras for confidence',
+      category_type: 'goal',
+      parent_id: null,
+      is_active: true,
+    },
+  ];
+
+  const setup = (navOverrides?: any) =>
+    render(
+      <SavedProvider>
+        <HomeScreen navigation={{ navigate: mockNavigate, reset: mockReset, ...navOverrides }} />
+      </SavedProvider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (collectionService.getUserCollections as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { collections: [] },
+    });
+    (categoryService.getAllCategories as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { categories: mockCategories },
+    });
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { reminders: [] },
+    });
+  });
+
+  it('loads categories on mount', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [],
+    });
+
+    setup();
+
+    await waitFor(
+      () => {
+        expect(categoryService.getAllCategories).toHaveBeenCalledWith('token');
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
+
+  it('handles loadCategories error gracefully', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [],
+    });
+    (categoryService.getAllCategories as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    setup();
+
+    await waitFor(
+      () => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error fetching categories:',
+          expect.any(Error),
+        );
+      },
+      { timeout: 10000 },
+    );
+
+    consoleErrorSpy.mockRestore();
+  }, 15000);
+
+  it('opens category filter sheet when filter button is pressed', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [{ mantra_id: 1, title: 'M1', isLiked: false, isSaved: false }],
+    });
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('category-filter-btn'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('category-filter-btn'));
+
+    await waitFor(
+      () => {
+        expect(getByTestId('category-filter-sheet')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
+
+  it('closes category filter sheet when close is pressed', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [{ mantra_id: 1, title: 'M1', isLiked: false, isSaved: false }],
+    });
+
+    const { getByTestId, queryByTestId } = setup();
+
+    await waitFor(() => getByTestId('category-filter-btn'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('category-filter-btn'));
+
+    await waitFor(() => expect(getByTestId('category-filter-sheet')).toBeTruthy(), {
+      timeout: 10000,
+    });
+
+    fireEvent.press(getByTestId('close-filter'));
+
+    await waitFor(() => expect(queryByTestId('category-filter-sheet')).toBeNull(), {
+      timeout: 10000,
+    });
+  }, 15000);
+
+  it('filters mantras when category is selected via filter sheet', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          mantra_id: 1,
+          title: 'Mental Health Mantra',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 1, name: 'Mind & Emotional Health' }],
+        },
+        {
+          mantra_id: 2,
+          title: 'Confidence Mantra',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 20, name: 'Boost Confidence' }],
+        },
+      ],
+    });
+
+    const { getByTestId, getByText, queryByText } = setup();
+
+    await waitFor(() => getByText('Mental Health Mantra'), { timeout: 10000 });
+
+    // Open filter and select category 1
+    fireEvent.press(getByTestId('category-filter-btn'));
+    await waitFor(() => getByTestId('category-filter-sheet'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('filter-cat-1'));
+
+    // Only Mental Health Mantra should be visible
+    await waitFor(
+      () => {
+        expect(getByText('Mental Health Mantra')).toBeTruthy();
+        expect(queryByText('Confidence Mantra')).toBeNull();
+      },
+      { timeout: 10000 },
+    );
+  }, 20000);
+
+  it('shows "No mantras match" when filter excludes all mantras', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          mantra_id: 1,
+          title: 'Some Mantra',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 1, name: 'Mind & Emotional Health' }],
+        },
+      ],
+    });
+
+    const { getByTestId, getByText } = setup();
+
+    await waitFor(() => getByText('Some Mantra'), { timeout: 10000 });
+
+    // Open filter and select category 20 (no mantras have this)
+    fireEvent.press(getByTestId('category-filter-btn'));
+    await waitFor(() => getByTestId('category-filter-sheet'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('filter-cat-20'));
+
+    await waitFor(
+      () => {
+        expect(getByText('No mantras match the selected categories')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+  }, 20000);
+
+  it('clears filters when "Clear Filters" button is pressed in empty state', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          mantra_id: 1,
+          title: 'Only Mantra',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 1, name: 'Mind & Emotional Health' }],
+        },
+      ],
+    });
+
+    const { getByTestId, getByText } = setup();
+
+    await waitFor(() => getByText('Only Mantra'), { timeout: 10000 });
+
+    // Select a category that excludes all mantras
+    fireEvent.press(getByTestId('category-filter-btn'));
+    await waitFor(() => getByTestId('category-filter-sheet'), { timeout: 10000 });
+    fireEvent.press(getByTestId('filter-cat-20'));
+
+    await waitFor(
+      () => {
+        expect(getByText('No mantras match the selected categories')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+
+    // Press Clear Filters
+    fireEvent.press(getByText('Clear Filters'));
+
+    await waitFor(
+      () => {
+        expect(getByText('Only Mantra')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+  }, 25000);
+
+  it('shows filter badge with count when categories are selected', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          mantra_id: 1,
+          title: 'M1',
+          isLiked: false,
+          isSaved: false,
+          categories: [
+            { category_id: 1, name: 'Mind & Emotional Health' },
+            { category_id: 20, name: 'Boost Confidence' },
+          ],
+        },
+      ],
+    });
+
+    const { getByTestId, getByText } = setup();
+
+    await waitFor(() => getByTestId('category-filter-btn'), { timeout: 10000 });
+
+    // Open filter and select a category
+    fireEvent.press(getByTestId('category-filter-btn'));
+    await waitFor(() => getByTestId('category-filter-sheet'), { timeout: 10000 });
+    fireEvent.press(getByTestId('filter-cat-1'));
+
+    // Badge count should be visible
+    await waitFor(
+      () => {
+        expect(getByText('1')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+  }, 20000);
+
+  it('handles loadCategories with non-success response', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [],
+    });
+    (categoryService.getAllCategories as jest.Mock).mockResolvedValue({
+      status: 'error',
+      message: 'Unauthorized',
+    });
+
+    setup();
+
+    await waitFor(
+      () => {
+        expect(categoryService.getAllCategories).toHaveBeenCalled();
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
+
+  it('uses mock-token when getToken returns null for loadCategories', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue(null);
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [],
+    });
+
+    setup();
+
+    await waitFor(
+      () => {
+        expect(categoryService.getAllCategories).toHaveBeenCalledWith('mock-token');
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
+
+  it('shows all mantras when no category filter is applied', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          mantra_id: 1,
+          title: 'Mantra A',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 1, name: 'Mind & Emotional Health' }],
+        },
+        {
+          mantra_id: 2,
+          title: 'Mantra B',
+          isLiked: false,
+          isSaved: false,
+          categories: [{ category_id: 20, name: 'Boost Confidence' }],
+        },
+      ],
+    });
+
+    const { getByText } = setup();
+
+    await waitFor(
+      () => {
+        expect(getByText('Mantra A')).toBeTruthy();
+        expect(getByText('Mantra B')).toBeTruthy();
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
+});
+
+// ─── Additional coverage: share, journal, rate, returnToMantraId ─────────────
+
+describe('HomeScreen - share, journal, rate, and route params', () => {
+  const mockNavigate = jest.fn();
+  const mockReset = jest.fn();
+  const mockSetParams = jest.fn();
+
+  const sampleMantras = [
+    { mantra_id: 1, title: 'M1', isLiked: false, isSaved: false },
+    { mantra_id: 2, title: 'M2', isLiked: false, isSaved: false },
+  ];
+
+  const setup = (navOverrides?: any, routeOverrides?: any) =>
+    render(
+      <SavedProvider>
+        <HomeScreen
+          navigation={{
+            navigate: mockNavigate,
+            reset: mockReset,
+            setParams: mockSetParams,
+            ...navOverrides,
+          }}
+          route={routeOverrides}
+        />
+      </SavedProvider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (collectionService.getUserCollections as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { collections: [] },
+    });
+    (categoryService.getAllCategories as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { categories: [] },
+    });
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { reminders: [] },
+    });
+  });
+
+  it('navigates to ShareMantra when share is pressed', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: sampleMantras,
+    });
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('share-1'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('share-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('ShareMantra', {
+      mantra: sampleMantras[0],
+    });
+  }, 15000);
+
+  it('navigates to JournalEditor when journal is pressed', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: sampleMantras,
+    });
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('journal-1'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('journal-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEditor', {
+      mantraId: 1,
+      mantraTitle: 'M1',
+    });
+  }, 15000);
+
+  it('calls ratingService.rateMantra on rate success and tracks engagement', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [{ mantra_id: 5, title: 'Rated Mantra', isLiked: false, isSaved: false }],
+    });
+    (mantraService.saveMantra as jest.Mock).mockResolvedValue({ status: 'success' });
+    (ratingService.rateMantra as jest.Mock).mockResolvedValue({ status: 'success' });
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('save-5'), { timeout: 10000 });
+
+    // Save to trigger popup bar
+    fireEvent.press(getByTestId('save-5'));
+
+    await waitFor(() => getByTestId('saved-popup-bar'), { timeout: 10000 });
+
+    // Press rate on the popup bar
+    fireEvent.press(getByTestId('rate-mantra'));
+
+    await waitFor(
+      () => {
+        expect(ratingService.rateMantra).toHaveBeenCalledWith(5, 5, undefined, 'token');
+        expect(engagementService.trackEvent).toHaveBeenCalledWith('mantra_rate');
+      },
+      { timeout: 10000 },
+    );
+  }, 20000);
+
+  it('shows alert when rateMantra returns non-success', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [{ mantra_id: 5, title: 'Rated Mantra', isLiked: false, isSaved: false }],
+    });
+    (mantraService.saveMantra as jest.Mock).mockResolvedValue({ status: 'success' });
+    (ratingService.rateMantra as jest.Mock).mockResolvedValue({
+      status: 'error',
+      message: 'Rating failed',
+    });
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('save-5'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('save-5'));
+    await waitFor(() => getByTestId('saved-popup-bar'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('rate-mantra'));
+
+    await waitFor(
+      () => {
+        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Rating failed');
+      },
+      { timeout: 10000 },
+    );
+  }, 20000);
+
+  it('shows alert when rateMantra throws an error', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: [{ mantra_id: 5, title: 'Rated Mantra', isLiked: false, isSaved: false }],
+    });
+    (mantraService.saveMantra as jest.Mock).mockResolvedValue({ status: 'success' });
+    (ratingService.rateMantra as jest.Mock).mockRejectedValue(new Error('Network failure'));
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { getByTestId } = setup();
+
+    await waitFor(() => getByTestId('save-5'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('save-5'));
+    await waitFor(() => getByTestId('saved-popup-bar'), { timeout: 10000 });
+
+    fireEvent.press(getByTestId('rate-mantra'));
+
+    await waitFor(
+      () => {
+        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to save rating');
+      },
+      { timeout: 10000 },
+    );
+
+    consoleErrorSpy.mockRestore();
+  }, 20000);
+
+  it('handles returnToMantraId with non-existent mantra id', async () => {
+    (storage.getToken as jest.Mock).mockResolvedValue('token');
+    (mantraService.getFeedMantras as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: sampleMantras,
+    });
+
+    setup({}, { params: { returnToMantraId: 999 } });
+
+    await waitFor(
+      () => {
+        expect(mockSetParams).toHaveBeenCalledWith({ returnToMantraId: undefined });
+      },
+      { timeout: 10000 },
+    );
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
Adds the ability to filter mantras by categories on the home screen. Users can now tap a filter button next to the search bar to open a modal sheet where they can select from multiple categories organized by type 

## Linked Story
Closes #472 

## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Other

## Evidence


https://github.com/user-attachments/assets/a022e939-6711-4ed6-925a-344dc46b206f



## Tests
- [x] Unit tests added/updated
- [x] CI passing

## Notes
Co-authored-by: @username (if pair/mob programming)
