### PR TITLE
fix-504 improve messaging load time and dates

### DIFF
--- a/apps/backend/database/chat-migration.sql
+++ b/apps/backend/database/chat-migration.sql
@@ -32,6 +32,7 @@ CREATE INDEX IF NOT EXISTS idx_conversation_user2 ON conversation(user2_id);
 CREATE INDEX IF NOT EXISTS idx_conversation_updated ON conversation(updated_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_message_conversation ON message(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_message_conversation_created_at ON message(conversation_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_message_sender ON message(sender_id);
 CREATE INDEX IF NOT EXISTS idx_message_created ON message(created_at);
 CREATE INDEX IF NOT EXISTS idx_message_read ON message(read) WHERE read = FALSE;

--- a/apps/backend/database/message-fetch-index-migration.sql
+++ b/apps/backend/database/message-fetch-index-migration.sql
@@ -1,0 +1,19 @@
+-- index to speed up message fetches by conversation ordered by time
+-- Handles both quoted ("Message") and unquoted/lowercase (message) table variants.
+
+DO $$
+BEGIN
+    IF to_regclass('"Message"') IS NOT NULL THEN
+        EXECUTE '
+            CREATE INDEX IF NOT EXISTS idx_message_conversation_created_at
+            ON "Message" ("conversation_id", "created_at" DESC)
+        ';
+    ELSIF to_regclass('message') IS NOT NULL THEN
+        EXECUTE '
+            CREATE INDEX IF NOT EXISTS idx_message_conversation_created_at
+            ON message (conversation_id, created_at DESC)
+        ';
+    ELSE
+        RAISE NOTICE 'Skipping message index migration: message table not found.';
+    END IF;
+END $$;

--- a/apps/backend/src/controllers/chat.controller.ts
+++ b/apps/backend/src/controllers/chat.controller.ts
@@ -120,6 +120,11 @@ export const ChatController = {
     try {
       const userId = req.user?.userId;
       const conversationId = Number(req.params.id);
+      const requestedLimit = Number(req.query.limit);
+      const safeLimit =
+        Number.isFinite(requestedLimit) && requestedLimit > 0
+          ? Math.min(Math.floor(requestedLimit), 100)
+          : 50;
 
       if (!userId) {
         return res.status(401).json({
@@ -138,7 +143,7 @@ export const ChatController = {
         });
       }
 
-      const messages = await MessageModel.findByConversationId(conversationId);
+      const messages = await MessageModel.findByConversationId(conversationId, safeLimit);
 
       return res.status(200).json({
         status: 'success',

--- a/apps/backend/src/models/message.model.ts
+++ b/apps/backend/src/models/message.model.ts
@@ -26,8 +26,21 @@ export const MessageModel = {
       .executeTakeFirst();
   },
 
-  // Get all messages in a conversation
-  async findByConversationId(conversationId: number): Promise<Message[]> {
+  // Get messages in a conversation
+  async findByConversationId(conversationId: number, limit?: number): Promise<Message[]> {
+    if (typeof limit === 'number' && limit > 0) {
+      // Fetch latest N first, then return ascending so chat renders oldest to newest.
+      const latestMessages = await db
+        .selectFrom('Message')
+        .where('conversation_id', '=', conversationId)
+        .selectAll()
+        .orderBy('created_at', 'desc')
+        .limit(limit)
+        .execute();
+
+      return latestMessages.reverse();
+    }
+
     return await db
       .selectFrom('Message')
       .where('conversation_id', '=', conversationId)

--- a/apps/backend/test/controllers/chat.controller.test.ts
+++ b/apps/backend/test/controllers/chat.controller.test.ts
@@ -39,9 +39,27 @@ describe('ChatController', () => {
   describe('getChatUsers', () => {
     it('should return all users except current user', async () => {
       const mockUsers = [
-        { user_id: 1, username: 'user1', email: 'user1@example.com', auth_provider: 'local', created_at: '2024-01-01' },
-        { user_id: 2, username: 'user2', email: 'user2@example.com', auth_provider: 'local', created_at: '2024-01-02' },
-        { user_id: 3, username: 'user3', email: 'user3@example.com', auth_provider: 'local', created_at: '2024-01-03' },
+        {
+          user_id: 1,
+          username: 'user1',
+          email: 'user1@example.com',
+          auth_provider: 'local',
+          created_at: '2024-01-01',
+        },
+        {
+          user_id: 2,
+          username: 'user2',
+          email: 'user2@example.com',
+          auth_provider: 'local',
+          created_at: '2024-01-02',
+        },
+        {
+          user_id: 3,
+          username: 'user3',
+          email: 'user3@example.com',
+          auth_provider: 'local',
+          created_at: '2024-01-03',
+        },
       ];
       (UserModel.findAll as jest.Mock).mockResolvedValue(mockUsers);
 
@@ -166,6 +184,17 @@ describe('ChatController', () => {
       expect(res.status).toBe(200);
       expect(res.body.status).toBe('success');
       expect(res.body.data.messages).toEqual(mockMessages);
+      expect(MessageModel.findByConversationId).toHaveBeenCalledWith(1, 50);
+    });
+
+    it('should respect limit query param for messages', async () => {
+      (ConversationModel.isParticipant as jest.Mock).mockResolvedValue(true);
+      (MessageModel.findByConversationId as jest.Mock).mockResolvedValue([]);
+
+      const res = await request(app).get('/api/chat/conversations/1/messages?limit=20');
+
+      expect(res.status).toBe(200);
+      expect(MessageModel.findByConversationId).toHaveBeenCalledWith(1, 20);
     });
 
     it('should return 403 if user is not participant', async () => {

--- a/apps/mobile/screens/ConversationScreen.tsx
+++ b/apps/mobile/screens/ConversationScreen.tsx
@@ -17,6 +17,9 @@ import { storage } from '../utils/storage';
 import { Ionicons } from '@expo/vector-icons';
 
 export default function ConversationScreen({ route, navigation }: any) {
+  const INITIAL_MESSAGE_LIMIT = 50;
+  const INITIAL_REACTION_HYDRATION_LIMIT = 20;
+
   const { conversation } = route.params as { conversation: Conversation };
   const { colors } = useTheme();
   const [messages, setMessages] = useState<Message[]>([]);
@@ -49,24 +52,39 @@ export default function ConversationScreen({ route, navigation }: any) {
       const data = await chatService.getMessages(
         conversation.conversation_id,
         token || 'mock-token',
+        INITIAL_MESSAGE_LIMIT,
       );
 
-      const messagesWithReactions = await Promise.all(
-        data.map(async (msg) => {
+      // Render messages immediately and load reactions in the background
+      setMessages(data.map((msg) => ({ ...msg, reactions: msg.reactions ?? [] })));
+      setLoading(false);
+
+      const messagesForReactionHydration = data.slice(-INITIAL_REACTION_HYDRATION_LIMIT);
+      void Promise.all(
+        messagesForReactionHydration.map(async (msg) => {
           try {
             const reactions = await chatService.getReactions(msg.message_id, token || 'mock-token');
-            return { ...msg, reactions };
+            return { messageId: msg.message_id, reactions };
           } catch (err) {
             console.error('Error loading reactions for message:', msg.message_id, err);
-            return { ...msg, reactions: [] };
+            return { messageId: msg.message_id, reactions: [] };
           }
         }),
-      );
+      ).then((reactionEntries) => {
+        setMessages((prevMessages) => {
+          const reactionsByMessageId = new Map(
+            reactionEntries.map((entry) => [entry.messageId, entry.reactions]),
+          );
 
-      setMessages(messagesWithReactions);
+          return prevMessages.map((msg) => {
+            const reactions = reactionsByMessageId.get(msg.message_id);
+            return reactions ? { ...msg, reactions } : msg;
+          });
+        });
+      });
 
       // Mark as read
-      await chatService.markAsRead(conversation.conversation_id, token || 'mock-token');
+      void chatService.markAsRead(conversation.conversation_id, token || 'mock-token');
     } catch (err) {
       console.error('Error loading messages:', err);
       Alert.alert('Error', 'Failed to load messages. Please try again.');

--- a/apps/mobile/screens/ConversationScreen.tsx
+++ b/apps/mobile/screens/ConversationScreen.tsx
@@ -146,6 +146,32 @@ export default function ConversationScreen({ route, navigation }: any) {
     }
   };
 
+  const getDayKey = (isoString: string) => {
+    const date = new Date(isoString);
+    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+  };
+
+  const formatDayHeader = (isoString: string) => {
+    const messageDate = new Date(isoString);
+    const today = new Date();
+
+    if (getDayKey(isoString) === getDayKey(today.toISOString())) {
+      return 'Today';
+    }
+
+    return messageDate.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const shouldShowDayHeader = (index: number) => {
+    if (index === 0) return true;
+    return getDayKey(messages[index].created_at) !== getDayKey(messages[index - 1].created_at);
+  };
+
   const renderContent = () => {
     if (loading) {
       return (
@@ -171,15 +197,30 @@ export default function ConversationScreen({ route, navigation }: any) {
         data={messages}
         keyExtractor={(item) => item.message_id.toString()}
         contentContainerStyle={{ paddingVertical: 16 }}
-        renderItem={({ item }) => (
-          <ChatBubble
-            message={item}
-            isOwnMessage={item.sender_id === currentUserId}
-            onSwipeReply={handleSwipeReply}
-            replyToMessage={getReplyToMessage(item.reply_to_message_id)}
-            onReaction={handleReaction}
-            currentUserId={currentUserId}
-          />
+        renderItem={({ item, index }) => (
+          <>
+            {shouldShowDayHeader(index) && (
+              <View className="items-center my-2">
+                <View
+                  className="px-3 py-1 rounded-full"
+                  style={{ backgroundColor: `${colors.white}40` }}
+                >
+                  <AppText className="text-[12px] font-semibold" style={{ color: colors.white }}>
+                    {formatDayHeader(item.created_at)}
+                  </AppText>
+                </View>
+              </View>
+            )}
+
+            <ChatBubble
+              message={item}
+              isOwnMessage={item.sender_id === currentUserId}
+              onSwipeReply={handleSwipeReply}
+              replyToMessage={getReplyToMessage(item.reply_to_message_id)}
+              onReaction={handleReaction}
+              currentUserId={currentUserId}
+            />
+          </>
         )}
         onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
         onLayout={() => flatListRef.current?.scrollToEnd({ animated: false })}

--- a/apps/mobile/screens/ConversationScreen.tsx
+++ b/apps/mobile/screens/ConversationScreen.tsx
@@ -11,7 +11,7 @@ import { useTheme } from '../context/ThemeContext';
 import AppText from '../components/UI/textWrapper';
 import { ChatBubble } from '../components/chat/ChatBubble';
 import ChatInput from '../components/chat/ChatInput';
-import { Message, Conversation } from '../types/chat.types';
+import { Message, Conversation, MessageReaction } from '../types/chat.types';
 import { chatService } from '../services/chat.service';
 import { storage } from '../utils/storage';
 import { Ionicons } from '@expo/vector-icons';
@@ -45,6 +45,38 @@ export default function ConversationScreen({ route, navigation }: any) {
     }
   };
 
+  const fetchReactionsForMessage = async (messageId: number, token: string) => {
+    try {
+      const reactions = await chatService.getReactions(messageId, token);
+      return { messageId, reactions };
+    } catch (err) {
+      console.error('Error loading reactions for message:', messageId, err);
+      return { messageId, reactions: [] };
+    }
+  };
+
+  const mergeReactionsIntoMessages = (
+    prevMessages: Message[],
+    reactionEntries: Array<{ messageId: number; reactions: MessageReaction[] }>,
+  ) => {
+    const reactionsByMessageId = new Map(
+      reactionEntries.map((entry) => [entry.messageId, entry.reactions]),
+    );
+
+    return prevMessages.map((msg) => {
+      const reactions = reactionsByMessageId.get(msg.message_id);
+      return reactions ? { ...msg, reactions } : msg;
+    });
+  };
+
+  const hydrateReactions = async (messagesToHydrate: Message[], token: string) => {
+    const reactionEntries = await Promise.all(
+      messagesToHydrate.map((msg) => fetchReactionsForMessage(msg.message_id, token)),
+    );
+
+    setMessages((prevMessages) => mergeReactionsIntoMessages(prevMessages, reactionEntries));
+  };
+
   const loadMessages = async () => {
     try {
       setLoading(true);
@@ -60,28 +92,7 @@ export default function ConversationScreen({ route, navigation }: any) {
       setLoading(false);
 
       const messagesForReactionHydration = data.slice(-INITIAL_REACTION_HYDRATION_LIMIT);
-      void Promise.all(
-        messagesForReactionHydration.map(async (msg) => {
-          try {
-            const reactions = await chatService.getReactions(msg.message_id, token || 'mock-token');
-            return { messageId: msg.message_id, reactions };
-          } catch (err) {
-            console.error('Error loading reactions for message:', msg.message_id, err);
-            return { messageId: msg.message_id, reactions: [] };
-          }
-        }),
-      ).then((reactionEntries) => {
-        setMessages((prevMessages) => {
-          const reactionsByMessageId = new Map(
-            reactionEntries.map((entry) => [entry.messageId, entry.reactions]),
-          );
-
-          return prevMessages.map((msg) => {
-            const reactions = reactionsByMessageId.get(msg.message_id);
-            return reactions ? { ...msg, reactions } : msg;
-          });
-        });
-      });
+      void hydrateReactions(messagesForReactionHydration, token || 'mock-token');
 
       // Mark as read
       void chatService.markAsRead(conversation.conversation_id, token || 'mock-token');

--- a/apps/mobile/services/chat.service.ts
+++ b/apps/mobile/services/chat.service.ts
@@ -116,9 +116,12 @@ const mockChatService = {
     });
   },
 
-  async getMessages(conversationId: number, token: string): Promise<Message[]> {
+  async getMessages(conversationId: number, token: string, limit?: number): Promise<Message[]> {
     return new Promise((resolve) => {
-      setTimeout(() => resolve(mockMessages[conversationId] || []), 500);
+      setTimeout(() => {
+        const messages = mockMessages[conversationId] || [];
+        resolve(typeof limit === 'number' && limit > 0 ? messages.slice(-limit) : messages);
+      }, 500);
     });
   },
 
@@ -191,10 +194,22 @@ const realChatService = {
     return response.data.data.conversations;
   },
 
-  async getMessages(conversationId: number, token: string): Promise<Message[]> {
-    const response = await apiClient.get(`/chat/conversations/${conversationId}/messages`, {
+  async getMessages(conversationId: number, token: string, limit?: number): Promise<Message[]> {
+    const requestConfig: {
+      headers: { Authorization: string };
+      params?: { limit: number };
+    } = {
       headers: { Authorization: `Bearer ${token}` },
-    });
+    };
+
+    if (typeof limit === 'number' && limit > 0) {
+      requestConfig.params = { limit };
+    }
+
+    const response = await apiClient.get(
+      `/chat/conversations/${conversationId}/messages`,
+      requestConfig,
+    );
     return response.data.data.messages;
   },
 

--- a/apps/mobile/test/screens/conversationScreen.test.tsx
+++ b/apps/mobile/test/screens/conversationScreen.test.tsx
@@ -146,7 +146,7 @@ describe('ConversationScreen', () => {
     );
 
     await waitFor(() => {
-      expect(chatService.getMessages).toHaveBeenCalledWith(1, 'mock-token');
+      expect(chatService.getMessages).toHaveBeenCalledWith(1, 'mock-token', 50);
     });
 
     expect(await findByText('Hello!', {}, { timeout: 10000 })).toBeTruthy();

--- a/apps/mobile/test/screens/conversationScreen.test.tsx
+++ b/apps/mobile/test/screens/conversationScreen.test.tsx
@@ -417,4 +417,44 @@ describe('ConversationScreen', () => {
       expect(queryByText('Hello!')).toBeNull();
     });
   });
+
+  it('shows Today and date headers like messenger style', async () => {
+    const oneDayAgo = new Date();
+    oneDayAgo.setDate(oneDayAgo.getDate() - 1);
+
+    const mixedDayMessages: Message[] = [
+      {
+        message_id: 101,
+        conversation_id: 1,
+        sender_id: 2,
+        content: 'Yesterday message',
+        created_at: oneDayAgo.toISOString(),
+        read: true,
+      },
+      {
+        message_id: 102,
+        conversation_id: 1,
+        sender_id: 1,
+        content: 'Today message',
+        created_at: new Date().toISOString(),
+        read: true,
+      },
+    ];
+
+    (chatService.getMessages as jest.Mock).mockResolvedValue(mixedDayMessages);
+
+    const { findByText, queryByText } = render(
+      <ConversationScreen route={mockRoute} navigation={mockNavigation} />,
+    );
+
+    const olderDayHeader = oneDayAgo.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+    expect(await findByText('Today')).toBeTruthy();
+    expect(queryByText(olderDayHeader)).toBeTruthy();
+  });
 });

--- a/apps/mobile/test/services/chat.service.test.ts
+++ b/apps/mobile/test/services/chat.service.test.ts
@@ -104,6 +104,23 @@ describe('chatService', () => {
 
       await expect(chatService.getMessages(1, mockToken)).rejects.toThrow('Not found');
     });
+
+    it('passes limit query param when provided', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: {
+          data: {
+            messages: [],
+          },
+        },
+      });
+
+      await chatService.getMessages(1, mockToken, 50);
+
+      expect(apiClient.get).toHaveBeenCalledWith('/chat/conversations/1/messages', {
+        headers: { Authorization: `Bearer ${mockToken}` },
+        params: { limit: 50 },
+      });
+    });
   });
 
   describe('sendMessage', () => {


### PR DESCRIPTION
## Summary
Fixed the long message load time by 
- limiting to only the 50 most recent messages on first load
- load reactions in the background only for the 20 most recent messages (this was the biggest factor to why it took too long to load, for each message there was a reaction API call)
- render messages immediately instead of waiting for reaction emoji API calls to finish.
- Added indexing on both conversation_id and created_at

Also added dates in the messaging for older messages and "Today" for messages sent in the same day as seen in the screenshot:
<img width="381" height="859" alt="image" src="https://github.com/user-attachments/assets/c75bc801-57d2-4186-8f4c-25e957cb8858" />


## Linked Story
Closes #504 

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Other

## Tests
- [x] Unit tests added/updated
- [x] CI passing

## Notes
Co-authored-by: @username (if pair/mob programming)
