### PR TITLE
journal reminders

### DIFF
--- a/apps/backend/database/journal-reminder-migration.sql
+++ b/apps/backend/database/journal-reminder-migration.sql
@@ -1,0 +1,17 @@
+-- Migration: Add journal entry support to Reminder table
+-- Feature: Reminders can now point to journal entries in addition to mantras and collections
+-- Date: 2026-04-06
+
+-- Add journal_id column to allow reminders to point to journal entries
+-- A reminder can point to a mantra (mantra_id), collection (collection_id), OR journal entry (journal_id), but only one
+ALTER TABLE "Reminder" ADD COLUMN IF NOT EXISTS "journal_id" INT;
+
+-- Add foreign key constraint for journal_id
+ALTER TABLE "Reminder" ADD CONSTRAINT fk_reminder_journal
+FOREIGN KEY ("journal_id") REFERENCES "JournalEntry" ("journal_id") ON DELETE CASCADE;
+
+-- Create index for efficient querying of journal-based reminders
+CREATE INDEX IF NOT EXISTS idx_reminder_journal ON "Reminder"(journal_id);
+
+-- Comments for documentation
+COMMENT ON COLUMN "Reminder".journal_id IS 'Optional reference to a journal entry. If set, the reminder points to a journal entry instead of a mantra or collection.';

--- a/apps/backend/src/models/reminder.model.ts
+++ b/apps/backend/src/models/reminder.model.ts
@@ -51,20 +51,28 @@ export const ReminderModel = {
       .execute();
   },
 
-  // Get all reminders for a user with linked mantra/collection names
-  async findByUserIdWithNames(
-    userId: number,
-  ): Promise<Array<Reminder & { mantra_title: string | null; collection_name: string | null }>> {
+  // Get all reminders for a user with linked mantra/collection/journal names
+  async findByUserIdWithNames(userId: number): Promise<
+    Array<
+      Reminder & {
+        mantra_title: string | null;
+        collection_name: string | null;
+        journal_title: string | null;
+      }
+    >
+  > {
     return await db
       .selectFrom('Reminder')
       .leftJoin('Mantra', 'Mantra.mantra_id', 'Reminder.mantra_id')
       .leftJoin('Collection', 'Collection.collection_id', 'Reminder.collection_id')
+      .leftJoin('JournalEntry', 'JournalEntry.journal_id', 'Reminder.journal_id')
       .where('Reminder.user_id', '=', userId)
       .select([
         'Reminder.reminder_id',
         'Reminder.user_id',
         'Reminder.mantra_id',
         'Reminder.collection_id',
+        'Reminder.journal_id',
         'Reminder.time',
         'Reminder.frequency',
         'Reminder.status',
@@ -74,6 +82,7 @@ export const ReminderModel = {
         'Reminder.timezone',
         'Mantra.title as mantra_title',
         'Collection.name as collection_name',
+        'JournalEntry.title as journal_title',
       ])
       .orderBy('Reminder.time', 'asc')
       .execute();
@@ -306,6 +315,7 @@ export const ReminderModel = {
         user_id: result.user_id,
         mantra_id: result.mantra_id,
         collection_id: result.collection_id,
+        journal_id: null,
         time: result.time,
         frequency: result.frequency,
         status: result.status,
@@ -350,6 +360,7 @@ export const ReminderModel = {
       .innerJoin('Mantra', 'Mantra.mantra_id', 'Reminder.mantra_id')
       .where('Reminder.status', '=', 'active')
       .where('Reminder.collection_id', 'is', null)
+      .where('Reminder.journal_id', 'is', null)
       .where((eb) => buildDueReminderFilter(eb, now.toISOString()))
       .select([
         'Reminder.reminder_id',
@@ -448,5 +459,85 @@ export const ReminderModel = {
       .executeTakeFirst();
 
     return Number(result.numDeletedRows);
+  },
+
+  // Get reminders by journal entry
+  async findByJournalId(journalId: number): Promise<Reminder[]> {
+    return await db
+      .selectFrom('Reminder')
+      .where('journal_id', '=', journalId)
+      .selectAll()
+      .orderBy('time', 'asc')
+      .execute();
+  },
+
+  // Get reminders for a specific user and journal combination
+  async findByUserAndJournal(userId: number, journalId: number): Promise<Reminder[]> {
+    return await db
+      .selectFrom('Reminder')
+      .where('user_id', '=', userId)
+      .where('journal_id', '=', journalId)
+      .selectAll()
+      .orderBy('time', 'asc')
+      .execute();
+  },
+
+  // Delete all reminders for a journal entry (when journal entry is deleted)
+  async deleteByJournalId(journalId: number): Promise<number> {
+    const result = await db
+      .deleteFrom('Reminder')
+      .where('journal_id', '=', journalId)
+      .executeTakeFirst();
+
+    return Number(result.numDeletedRows);
+  },
+
+  /**
+   * Get all due journal reminders with user and journal details
+   * This is an optimized query for journal-based reminders
+   */
+  async findDueJournalRemindersWithDetails(): Promise<
+    Array<{
+      reminder_id: number;
+      user_id: number | null;
+      journal_id: number | null;
+      time: string | null;
+      frequency: string | null;
+      status: string | null;
+      last_sent_at: string | null;
+      user_device_token: string | null;
+      journal_title: string | null;
+      journal_content: string | null;
+      schedule_times: string[] | null;
+      schedule_days: number[] | null;
+      timezone: string | null;
+    }>
+  > {
+    const now = new Date();
+
+    return await db
+      .selectFrom('Reminder')
+      .innerJoin('User', 'User.user_id', 'Reminder.user_id')
+      .innerJoin('JournalEntry', 'JournalEntry.journal_id', 'Reminder.journal_id')
+      .where('Reminder.status', '=', 'active')
+      .where('Reminder.journal_id', 'is not', null)
+      .where((eb) => buildDueReminderFilter(eb, now.toISOString()))
+      .select([
+        'Reminder.reminder_id',
+        'Reminder.user_id',
+        'Reminder.journal_id',
+        'Reminder.time',
+        'Reminder.frequency',
+        'Reminder.status',
+        'Reminder.last_sent_at',
+        'Reminder.schedule_times',
+        'Reminder.schedule_days',
+        'Reminder.timezone',
+        'User.device_token as user_device_token',
+        'JournalEntry.title as journal_title',
+        'JournalEntry.content as journal_content',
+      ])
+      .orderBy('Reminder.time', 'asc')
+      .execute();
   },
 };

--- a/apps/backend/src/models/reminder.model.ts
+++ b/apps/backend/src/models/reminder.model.ts
@@ -88,25 +88,52 @@ export const ReminderModel = {
       .execute();
   },
 
-  // Get all reminders for a specific mantra
-  async findByMantraId(mantraId: number): Promise<Reminder[]> {
+  // Generic: find reminders by a specific column
+  async findByColumn(
+    column: 'mantra_id' | 'collection_id' | 'journal_id',
+    value: number,
+  ): Promise<Reminder[]> {
     return await db
       .selectFrom('Reminder')
-      .where('mantra_id', '=', mantraId)
+      .where(column, '=', value)
       .selectAll()
       .orderBy('time', 'asc')
       .execute();
   },
 
-  // Get reminders for a specific user and mantra combination
-  async findByUserAndMantra(userId: number, mantraId: number): Promise<Reminder[]> {
+  // Generic: find reminders for a specific user and column combination
+  async findByUserAndColumn(
+    userId: number,
+    column: 'mantra_id' | 'collection_id' | 'journal_id',
+    value: number,
+  ): Promise<Reminder[]> {
     return await db
       .selectFrom('Reminder')
       .where('user_id', '=', userId)
-      .where('mantra_id', '=', mantraId)
+      .where(column, '=', value)
       .selectAll()
       .orderBy('time', 'asc')
       .execute();
+  },
+
+  // Generic: delete all reminders by a specific column
+  async deleteByColumn(
+    column: 'mantra_id' | 'collection_id' | 'journal_id',
+    value: number,
+  ): Promise<number> {
+    const result = await db.deleteFrom('Reminder').where(column, '=', value).executeTakeFirst();
+
+    return Number(result.numDeletedRows);
+  },
+
+  // Get all reminders for a specific mantra
+  async findByMantraId(mantraId: number): Promise<Reminder[]> {
+    return this.findByColumn('mantra_id', mantraId);
+  },
+
+  // Get reminders for a specific user and mantra combination
+  async findByUserAndMantra(userId: number, mantraId: number): Promise<Reminder[]> {
+    return this.findByUserAndColumn(userId, 'mantra_id', mantraId);
   },
 
   // Get active reminders for a user
@@ -180,12 +207,7 @@ export const ReminderModel = {
 
   // Delete all reminders for a mantra (when mantra is deleted)
   async deleteByMantraId(mantraId: number): Promise<number> {
-    const result = await db
-      .deleteFrom('Reminder')
-      .where('mantra_id', '=', mantraId)
-      .executeTakeFirst();
-
-    return Number(result.numDeletedRows);
+    return this.deleteByColumn('mantra_id', mantraId);
   },
 
   // Count reminders for a user
@@ -432,64 +454,32 @@ export const ReminderModel = {
 
   // Get reminders by collection
   async findByCollectionId(collectionId: number): Promise<Reminder[]> {
-    return await db
-      .selectFrom('Reminder')
-      .where('collection_id', '=', collectionId)
-      .selectAll()
-      .orderBy('time', 'asc')
-      .execute();
+    return this.findByColumn('collection_id', collectionId);
   },
 
   // Get reminders for a specific user and collection combination
   async findByUserAndCollection(userId: number, collectionId: number): Promise<Reminder[]> {
-    return await db
-      .selectFrom('Reminder')
-      .where('user_id', '=', userId)
-      .where('collection_id', '=', collectionId)
-      .selectAll()
-      .orderBy('time', 'asc')
-      .execute();
+    return this.findByUserAndColumn(userId, 'collection_id', collectionId);
   },
 
   // Delete all reminders for a collection (when collection is deleted)
   async deleteByCollectionId(collectionId: number): Promise<number> {
-    const result = await db
-      .deleteFrom('Reminder')
-      .where('collection_id', '=', collectionId)
-      .executeTakeFirst();
-
-    return Number(result.numDeletedRows);
+    return this.deleteByColumn('collection_id', collectionId);
   },
 
   // Get reminders by journal entry
   async findByJournalId(journalId: number): Promise<Reminder[]> {
-    return await db
-      .selectFrom('Reminder')
-      .where('journal_id', '=', journalId)
-      .selectAll()
-      .orderBy('time', 'asc')
-      .execute();
+    return this.findByColumn('journal_id', journalId);
   },
 
   // Get reminders for a specific user and journal combination
   async findByUserAndJournal(userId: number, journalId: number): Promise<Reminder[]> {
-    return await db
-      .selectFrom('Reminder')
-      .where('user_id', '=', userId)
-      .where('journal_id', '=', journalId)
-      .selectAll()
-      .orderBy('time', 'asc')
-      .execute();
+    return this.findByUserAndColumn(userId, 'journal_id', journalId);
   },
 
   // Delete all reminders for a journal entry (when journal entry is deleted)
   async deleteByJournalId(journalId: number): Promise<number> {
-    const result = await db
-      .deleteFrom('Reminder')
-      .where('journal_id', '=', journalId)
-      .executeTakeFirst();
-
-    return Number(result.numDeletedRows);
+    return this.deleteByColumn('journal_id', journalId);
   },
 
   /**

--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -226,6 +226,41 @@ export const NotificationService = {
   },
 
   /**
+   * Send journal reminder notification
+   * Deep links to a journal entry
+   * @param deviceToken - Expo push token
+   * @param journalTitle - The journal entry title for notification content
+   * @param journalContent - The journal entry content (used as fallback if no title)
+   * @param reminderId - The reminder ID for deep linking
+   * @param journalId - The journal entry ID for deep linking
+   * @param options - Optional notification content customization
+   * @returns Expo push response
+   */
+  async sendJournalReminderNotification(
+    deviceToken: string,
+    journalTitle: string | null,
+    journalContent: string,
+    reminderId: number,
+    journalId: number,
+    options?: Partial<NotificationContentOptions>,
+  ): Promise<ExpoPushResponse> {
+    const displayText = journalTitle || journalContent.substring(0, 100);
+    const journalText = `Revisit your journal entry: "${displayText}"`;
+
+    const { title, body } = generateNotificationContent({
+      mantraText: journalText,
+      ...options,
+    });
+
+    return await this.sendSimpleNotification(deviceToken, title, body, {
+      type: 'journal_reminder',
+      reminderId,
+      journalId,
+      journalTitle: displayText,
+    });
+  },
+
+  /**
    * Send bulk reminder notifications with enhanced content
    * Supports both mantra-based and collection-based reminders
    * @param notifications - Array of notification details

--- a/apps/backend/src/services/reminder-scheduler.service.ts
+++ b/apps/backend/src/services/reminder-scheduler.service.ts
@@ -48,6 +48,12 @@ interface CollectionReminderWithDetails extends BaseReminderDetails {
   collection_description: string | null;
 }
 
+interface JournalReminderWithDetails extends BaseReminderDetails {
+  journal_id: number | null;
+  journal_title: string | null;
+  journal_content: string | null;
+}
+
 interface ProcessResult {
   reminderId: number;
   success: boolean;
@@ -116,15 +122,18 @@ export const ReminderSchedulerService = {
       const dueReminders = await ReminderModel.findDueRemindersWithDetails();
       // Get all due collection-based reminders
       const dueCollectionReminders = await ReminderModel.findDueCollectionRemindersWithDetails();
+      // Get all due journal-based reminders
+      const dueJournalReminders = await ReminderModel.findDueJournalRemindersWithDetails();
 
-      const totalDue = dueReminders.length + dueCollectionReminders.length;
+      const totalDue =
+        dueReminders.length + dueCollectionReminders.length + dueJournalReminders.length;
 
       if (totalDue === 0) {
         return results;
       }
 
       console.log(
-        `📬 Processing ${totalDue} due reminder(s) (${dueReminders.length} mantra, ${dueCollectionReminders.length} collection)`,
+        `📬 Processing ${totalDue} due reminder(s) (${dueReminders.length} mantra, ${dueCollectionReminders.length} collection, ${dueJournalReminders.length} journal)`,
       );
 
       // Process mantra-based reminders
@@ -136,6 +145,12 @@ export const ReminderSchedulerService = {
       // Process collection-based reminders
       for (const reminder of dueCollectionReminders) {
         const result = await this.processCollectionReminder(reminder);
+        results.push(result);
+      }
+
+      // Process journal-based reminders
+      for (const reminder of dueJournalReminders) {
+        const result = await this.processJournalReminder(reminder);
         results.push(result);
       }
 
@@ -414,6 +429,46 @@ export const ReminderSchedulerService = {
       collection_name,
       reminder_id,
       collection_id,
+    );
+  },
+
+  /**
+   * Process a single journal-based reminder
+   * @param reminder - Journal reminder with user and journal details
+   */
+  async processJournalReminder(reminder: JournalReminderWithDetails): Promise<ProcessResult> {
+    return this.processReminderGeneric(
+      reminder,
+      'Journal Reminder' as any,
+      (r) => {
+        if (!r.journal_title && !r.journal_content) {
+          console.warn(
+            `⚠️  Journal Reminder ${r.reminder_id}: Journal has no title or content, skipping`,
+          );
+          return 'No journal content';
+        }
+        return null;
+      },
+      (r) => this.sendJournalReminderNotification(r),
+    );
+  },
+
+  /**
+   * Send the actual notification for a journal reminder
+   */
+  async sendJournalReminderNotification(reminder: JournalReminderWithDetails): Promise<void> {
+    const { reminder_id, journal_id, user_device_token, journal_title, journal_content } = reminder;
+
+    if (!user_device_token || !journal_id || (!journal_title && !journal_content)) {
+      throw new Error('Missing required notification data');
+    }
+
+    await NotificationService.sendJournalReminderNotification(
+      user_device_token,
+      journal_title,
+      journal_content ?? '',
+      reminder_id,
+      journal_id,
     );
   },
 

--- a/apps/backend/src/types/database.types.ts
+++ b/apps/backend/src/types/database.types.ts
@@ -106,6 +106,7 @@ export interface ReminderTable {
   user_id: number | null;
   mantra_id: number | null;
   collection_id: number | null;
+  journal_id: number | null;
   time: string | null;
   frequency: string | null;
   status: string | null;

--- a/apps/backend/src/validators/reminder.validator.ts
+++ b/apps/backend/src/validators/reminder.validator.ts
@@ -24,7 +24,7 @@ const uniqueScheduleTimesSchema = z
     message: 'Duplicate times are not allowed',
   });
 
-// Create reminder schema - requires either mantra_id or collection_id (not both)
+// Create reminder schema - requires exactly one of mantra_id, collection_id, or journal_id
 export const createReminderSchema = z.object({
   body: z
     .object({
@@ -34,6 +34,7 @@ export const createReminderSchema = z.object({
         .int()
         .positive('Collection ID must be a positive integer')
         .optional(),
+      journal_id: z.number().int().positive('Journal ID must be a positive integer').optional(),
       time: z.iso.datetime({ message: 'Must be a valid ISO 8601 datetime' }).optional(),
       frequency: reminderFrequencyEnum,
       status: reminderStatusEnum.optional().default('active'),
@@ -41,9 +42,17 @@ export const createReminderSchema = z.object({
       schedule_days: z.array(dayOfWeekSchema).min(1).max(7).optional(),
       timezone: timezoneSchema.optional(),
     })
-    .refine((data) => (data.mantra_id !== undefined) !== (data.collection_id !== undefined), {
-      message: 'Exactly one of mantra_id or collection_id must be provided',
-    })
+    .refine(
+      (data) => {
+        const count = [data.mantra_id, data.collection_id, data.journal_id].filter(
+          (id) => id !== undefined,
+        ).length;
+        return count === 1;
+      },
+      {
+        message: 'Exactly one of mantra_id, collection_id, or journal_id must be provided',
+      },
+    )
     .refine(
       (data) => {
         if (data.frequency === 'routine') {
@@ -67,6 +76,7 @@ export const updateReminderSchema = z.object({
   body: z.object({
     mantra_id: z.number().int().positive().optional(),
     collection_id: z.number().int().positive().optional(),
+    journal_id: z.number().int().positive().optional(),
     time: z.iso.datetime().optional(),
     frequency: reminderFrequencyEnum.optional(),
     status: reminderStatusEnum.optional(),

--- a/apps/backend/test/models/reminder.model.test.ts
+++ b/apps/backend/test/models/reminder.model.test.ts
@@ -961,6 +961,200 @@ describe('ReminderModel', () => {
     });
   });
 
+  describe('findByJournalId', () => {
+    it('should find all reminders for a journal entry', async () => {
+      const mockReminders: Reminder[] = [
+        {
+          reminder_id: 1,
+          user_id: 1,
+          mantra_id: null,
+          collection_id: null,
+          journal_id: 7,
+          time: '2024-12-01T09:00:00Z',
+          frequency: 'daily',
+          status: 'active',
+          last_sent_at: null,
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        selectAll: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue(mockReminders),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await ReminderModel.findByJournalId(7);
+
+      expect(db.selectFrom).toHaveBeenCalledWith('Reminder');
+      expect(mockChain.where).toHaveBeenCalledWith('journal_id', '=', 7);
+      expect(mockChain.orderBy).toHaveBeenCalledWith('time', 'asc');
+      expect(result).toEqual(mockReminders);
+    });
+  });
+
+  describe('findByUserAndJournal', () => {
+    it('should find reminders for specific user and journal', async () => {
+      const mockReminders: Reminder[] = [
+        {
+          reminder_id: 1,
+          user_id: 1,
+          mantra_id: null,
+          collection_id: null,
+          journal_id: 7,
+          time: '2024-12-01T09:00:00Z',
+          frequency: 'daily',
+          status: 'active',
+          last_sent_at: null,
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        selectAll: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue(mockReminders),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await ReminderModel.findByUserAndJournal(1, 7);
+
+      expect(mockChain.where).toHaveBeenCalledWith('user_id', '=', 1);
+      expect(mockChain.where).toHaveBeenCalledWith('journal_id', '=', 7);
+      expect(result).toEqual(mockReminders);
+    });
+  });
+
+  describe('deleteByJournalId', () => {
+    it('should delete all reminders for a journal entry', async () => {
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        executeTakeFirst: jest.fn().mockResolvedValue({ numDeletedRows: BigInt(2) }),
+      };
+
+      (db.deleteFrom as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await ReminderModel.deleteByJournalId(7);
+
+      expect(db.deleteFrom).toHaveBeenCalledWith('Reminder');
+      expect(mockChain.where).toHaveBeenCalledWith('journal_id', '=', 7);
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('findDueJournalRemindersWithDetails', () => {
+    it('should find due journal reminders with details', async () => {
+      const mockResults = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: '2024-12-01T09:00:00Z',
+          frequency: 'daily',
+          status: 'active',
+          last_sent_at: null,
+          user_device_token: 'ExponentPushToken[zzz]',
+          journal_title: 'My Journal Entry',
+          journal_content: 'Some content',
+        },
+      ];
+
+      const mockChain = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue(mockResults),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await ReminderModel.findDueJournalRemindersWithDetails();
+
+      expect(db.selectFrom).toHaveBeenCalledWith('Reminder');
+      expect(mockChain.innerJoin).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(1);
+      expect(result[0].journal_title).toBe('My Journal Entry');
+      expect(result[0].journal_content).toBe('Some content');
+    });
+  });
+
+  describe('findByColumn (generic helper)', () => {
+    it('should work for mantra_id column', async () => {
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        selectAll: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue([]),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      await ReminderModel.findByColumn('mantra_id', 5);
+
+      expect(mockChain.where).toHaveBeenCalledWith('mantra_id', '=', 5);
+    });
+
+    it('should work for collection_id column', async () => {
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        selectAll: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue([]),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      await ReminderModel.findByColumn('collection_id', 10);
+
+      expect(mockChain.where).toHaveBeenCalledWith('collection_id', '=', 10);
+    });
+  });
+
+  describe('findByUserAndColumn (generic helper)', () => {
+    it('should query by user_id and specified column', async () => {
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        selectAll: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue([]),
+      };
+
+      (db.selectFrom as jest.Mock).mockReturnValue(mockChain);
+
+      await ReminderModel.findByUserAndColumn(1, 'journal_id', 7);
+
+      expect(mockChain.where).toHaveBeenCalledWith('user_id', '=', 1);
+      expect(mockChain.where).toHaveBeenCalledWith('journal_id', '=', 7);
+    });
+  });
+
+  describe('deleteByColumn (generic helper)', () => {
+    it('should delete by specified column', async () => {
+      const mockChain = {
+        where: jest.fn().mockReturnThis(),
+        executeTakeFirst: jest.fn().mockResolvedValue({ numDeletedRows: BigInt(3) }),
+      };
+
+      (db.deleteFrom as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await ReminderModel.deleteByColumn('journal_id', 7);
+
+      expect(db.deleteFrom).toHaveBeenCalledWith('Reminder');
+      expect(mockChain.where).toHaveBeenCalledWith('journal_id', '=', 7);
+      expect(result).toBe(3);
+    });
+  });
+
   describe('countByUserId edge cases', () => {
     it('should return 0 when result is null', async () => {
       const mockChain = {

--- a/apps/backend/test/models/reminder.model.test.ts
+++ b/apps/backend/test/models/reminder.model.test.ts
@@ -31,6 +31,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'daily',
         status: 'active',
@@ -63,6 +64,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'daily',
         status: 'active',
@@ -110,6 +112,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -123,6 +126,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 10,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T18:00:00Z',
           frequency: 'weekly',
           status: 'active',
@@ -159,6 +163,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -194,6 +199,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -233,6 +239,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T10:00:00Z',
         frequency: 'weekly',
         status: 'active',
@@ -267,6 +274,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'daily',
         status: 'paused',
@@ -379,6 +387,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
           frequency: 'daily',
           status: 'active',
@@ -416,6 +425,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -451,6 +461,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -487,6 +498,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -540,6 +552,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'once',
           status: 'active',
@@ -575,6 +588,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'daily',
         status: 'active',
@@ -597,7 +611,9 @@ describe('ReminderModel', () => {
 
       expect(db.updateTable).toHaveBeenCalledWith('Reminder');
       expect(mockChain.where).toHaveBeenCalledWith('reminder_id', '=', 1);
-      expect(mockChain.set).toHaveBeenCalledWith(expect.objectContaining({ last_sent_at: expect.any(String) }));
+      expect(mockChain.set).toHaveBeenCalledWith(
+        expect.objectContaining({ last_sent_at: expect.any(String) }),
+      );
       expect(result).toEqual(mockReminder);
     });
   });
@@ -609,6 +625,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'once',
         status: 'completed',
@@ -631,10 +648,12 @@ describe('ReminderModel', () => {
 
       expect(db.updateTable).toHaveBeenCalledWith('Reminder');
       expect(mockChain.where).toHaveBeenCalledWith('reminder_id', '=', 1);
-      expect(mockChain.set).toHaveBeenCalledWith(expect.objectContaining({
-        status: 'completed',
-        last_sent_at: expect.any(String)
-      }));
+      expect(mockChain.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'completed',
+          last_sent_at: expect.any(String),
+        }),
+      );
       expect(result?.status).toBe('completed');
     });
   });
@@ -646,6 +665,7 @@ describe('ReminderModel', () => {
         user_id: 1,
         mantra_id: 5,
         collection_id: null,
+        journal_id: null,
         time: '2024-12-01T09:00:00Z',
         frequency: 'daily',
         status: 'active',
@@ -735,6 +755,7 @@ describe('ReminderModel', () => {
           reminder_id: 2,
           user_id: 1,
           collection_id: 10,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -772,6 +793,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: null,
           collection_id: 10,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -808,6 +830,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: null,
           collection_id: 10,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -860,6 +883,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: 5,
           collection_id: null,
+          journal_id: null,
           time: '2024-12-01T09:00:00Z',
           frequency: 'daily',
           status: 'active',
@@ -872,6 +896,7 @@ describe('ReminderModel', () => {
           user_id: 1,
           mantra_id: null,
           collection_id: 10,
+          journal_id: null,
           time: '2024-12-01T18:00:00Z',
           frequency: 'weekly',
           status: 'active',
@@ -894,9 +919,22 @@ describe('ReminderModel', () => {
       const result = await ReminderModel.findByUserIdWithNames(1);
 
       expect(db.selectFrom).toHaveBeenCalledWith('Reminder');
-      expect(mockChain.leftJoin).toHaveBeenCalledTimes(2);
-      expect(mockChain.leftJoin).toHaveBeenCalledWith('Mantra', 'Mantra.mantra_id', 'Reminder.mantra_id');
-      expect(mockChain.leftJoin).toHaveBeenCalledWith('Collection', 'Collection.collection_id', 'Reminder.collection_id');
+      expect(mockChain.leftJoin).toHaveBeenCalledTimes(3);
+      expect(mockChain.leftJoin).toHaveBeenCalledWith(
+        'Mantra',
+        'Mantra.mantra_id',
+        'Reminder.mantra_id',
+      );
+      expect(mockChain.leftJoin).toHaveBeenCalledWith(
+        'Collection',
+        'Collection.collection_id',
+        'Reminder.collection_id',
+      );
+      expect(mockChain.leftJoin).toHaveBeenCalledWith(
+        'JournalEntry',
+        'JournalEntry.journal_id',
+        'Reminder.journal_id',
+      );
       expect(mockChain.where).toHaveBeenCalledWith('Reminder.user_id', '=', 1);
       expect(mockChain.orderBy).toHaveBeenCalledWith('Reminder.time', 'asc');
       expect(result).toEqual(mockResults);
@@ -939,4 +977,3 @@ describe('ReminderModel', () => {
     });
   });
 });
-

--- a/apps/backend/test/services/notification.service.test.ts
+++ b/apps/backend/test/services/notification.service.test.ts
@@ -38,7 +38,7 @@ describe('NotificationService', () => {
             Accept: 'application/json',
             'Content-Type': 'application/json',
           }),
-        }
+        },
       );
       expect(result).toEqual(mockResponse.data);
     });
@@ -65,7 +65,7 @@ describe('NotificationService', () => {
       expect(mockedAxios.post).toHaveBeenCalledWith(
         'https://exp.host/--/api/v2/push/send',
         mockMessages,
-        expect.any(Object)
+        expect.any(Object),
       );
       expect(result.data).toHaveLength(2);
     });
@@ -78,7 +78,7 @@ describe('NotificationService', () => {
       };
 
       await expect(NotificationService.sendPushNotification(mockMessage)).rejects.toThrow(
-        'Invalid Expo push token: InvalidToken'
+        'Invalid Expo push token: InvalidToken',
       );
     });
 
@@ -92,7 +92,7 @@ describe('NotificationService', () => {
       mockedAxios.post.mockRejectedValue(new Error('Network error'));
 
       await expect(NotificationService.sendPushNotification(mockMessage)).rejects.toThrow(
-        'Network error'
+        'Network error',
       );
     });
   });
@@ -111,7 +111,7 @@ describe('NotificationService', () => {
         'ExponentPushToken[xxx]',
         'Title',
         'Body',
-        { key: 'value' }
+        { key: 'value' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -127,7 +127,7 @@ describe('NotificationService', () => {
             channelId: 'default',
           },
         ],
-        expect.any(Object)
+        expect.any(Object),
       );
       expect(result).toEqual(mockResponse.data);
     });
@@ -141,11 +141,7 @@ describe('NotificationService', () => {
 
       mockedAxios.post.mockResolvedValue(mockResponse);
 
-      await NotificationService.sendSimpleNotification(
-        'ExponentPushToken[xxx]',
-        'Title',
-        'Body'
-      );
+      await NotificationService.sendSimpleNotification('ExponentPushToken[xxx]', 'Title', 'Body');
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
         'https://exp.host/--/api/v2/push/send',
@@ -160,7 +156,7 @@ describe('NotificationService', () => {
             channelId: 'default',
           },
         ],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
   });
@@ -183,7 +179,7 @@ describe('NotificationService', () => {
         mockTokens,
         'Bulk Title',
         'Bulk Body',
-        { type: 'bulk' }
+        { type: 'bulk' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -208,7 +204,7 @@ describe('NotificationService', () => {
             channelId: 'default',
           },
         ],
-        expect.any(Object)
+        expect.any(Object),
       );
       expect(result.data).toHaveLength(2);
     });
@@ -225,11 +221,7 @@ describe('NotificationService', () => {
       mockedAxios.post.mockResolvedValue(mockResponse);
 
       const mantraText = 'I am strong and capable';
-      await NotificationService.sendReminderNotification(
-        'ExponentPushToken[xxx]',
-        mantraText,
-        123
-      );
+      await NotificationService.sendReminderNotification('ExponentPushToken[xxx]', mantraText, 123);
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
         'https://exp.host/--/api/v2/push/send',
@@ -249,7 +241,7 @@ describe('NotificationService', () => {
             channelId: 'default',
           },
         ],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -267,7 +259,7 @@ describe('NotificationService', () => {
         'ExponentPushToken[xxx]',
         mantraText,
         123,
-        456
+        456,
       );
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -288,7 +280,7 @@ describe('NotificationService', () => {
             channelId: 'default',
           },
         ],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -302,11 +294,7 @@ describe('NotificationService', () => {
       mockedAxios.post.mockResolvedValue(mockResponse);
 
       const longMantra = 'A'.repeat(150);
-      await NotificationService.sendReminderNotification(
-        'ExponentPushToken[xxx]',
-        longMantra,
-        123
-      );
+      await NotificationService.sendReminderNotification('ExponentPushToken[xxx]', longMantra, 123);
 
       const calledWith = mockedAxios.post.mock.calls[0][1] as any[];
       expect(calledWith[0].body).toBe('A'.repeat(97) + '...');
@@ -357,7 +345,7 @@ describe('NotificationService', () => {
             Accept: 'application/json',
             'Content-Type': 'application/json',
           }),
-        }
+        },
       );
       expect(result).toEqual(mockReceipts.data);
     });
@@ -441,7 +429,7 @@ describe('NotificationService', () => {
       await NotificationService.sendEnhancedReminderNotification(
         'ExponentPushToken[xxx]',
         mantraText,
-        123
+        123,
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -466,7 +454,7 @@ describe('NotificationService', () => {
         mantraText,
         123,
         456,
-        { categoryName: 'confidence' }
+        { categoryName: 'confidence' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -491,7 +479,7 @@ describe('NotificationService', () => {
         'I am confident',
         123,
         undefined,
-        { categoryName: 'confidence' }
+        { categoryName: 'confidence' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -511,7 +499,7 @@ describe('NotificationService', () => {
         'Test mantra',
         123,
         undefined,
-        { ctaStyle: 'encouraging' }
+        { ctaStyle: 'encouraging' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -532,7 +520,7 @@ describe('NotificationService', () => {
         'Test',
         123,
         undefined,
-        { customTitle }
+        { customTitle },
       );
 
       const calledWith = mockedAxios.post.mock.calls[0][1] as any[];
@@ -587,7 +575,7 @@ describe('NotificationService', () => {
             }),
           }),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -641,7 +629,7 @@ describe('NotificationService', () => {
             }),
           }),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -702,7 +690,7 @@ describe('NotificationService', () => {
             }),
           }),
         ]),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -758,7 +746,7 @@ describe('NotificationService', () => {
         'ExponentPushToken[xxx]',
         'My Collection',
         123,
-        456
+        456,
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -783,7 +771,7 @@ describe('NotificationService', () => {
         'My Collection',
         123,
         456,
-        5
+        5,
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -805,7 +793,7 @@ describe('NotificationService', () => {
         'ExponentPushToken[xxx]',
         'Morning Mantras',
         123,
-        456
+        456,
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -828,7 +816,79 @@ describe('NotificationService', () => {
         123,
         456,
         undefined,
-        { ctaStyle: 'encouraging' }
+        { ctaStyle: 'encouraging' },
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalled();
+    });
+  });
+
+  describe('sendJournalReminderNotification', () => {
+    it('should send journal reminder notification with title', async () => {
+      const mockResponse = {
+        data: {
+          data: [{ status: 'ok', id: 'receipt-id' }],
+        },
+      };
+
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      await NotificationService.sendJournalReminderNotification(
+        'ExponentPushToken[xxx]',
+        'My Journal Entry',
+        'Some content here',
+        123,
+        456,
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalled();
+      const calledWith = mockedAxios.post.mock.calls[0][1] as any[];
+      expect(calledWith[0].data.type).toBe('journal_reminder');
+      expect(calledWith[0].data.reminderId).toBe(123);
+      expect(calledWith[0].data.journalId).toBe(456);
+      expect(calledWith[0].data.journalTitle).toBe('My Journal Entry');
+    });
+
+    it('should use content substring as fallback when title is null', async () => {
+      const mockResponse = {
+        data: {
+          data: [{ status: 'ok', id: 'receipt-id' }],
+        },
+      };
+
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      const longContent = 'A'.repeat(200);
+      await NotificationService.sendJournalReminderNotification(
+        'ExponentPushToken[xxx]',
+        null,
+        longContent,
+        123,
+        456,
+      );
+
+      expect(mockedAxios.post).toHaveBeenCalled();
+      const calledWith = mockedAxios.post.mock.calls[0][1] as any[];
+      // displayText should be content.substring(0, 100)
+      expect(calledWith[0].data.journalTitle).toBe('A'.repeat(100));
+    });
+
+    it('should accept custom options for content generation', async () => {
+      const mockResponse = {
+        data: {
+          data: [{ status: 'ok', id: 'receipt-id' }],
+        },
+      };
+
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      await NotificationService.sendJournalReminderNotification(
+        'ExponentPushToken[xxx]',
+        'My Journal',
+        'Content',
+        123,
+        456,
+        { ctaStyle: 'encouraging' },
       );
 
       expect(mockedAxios.post).toHaveBeenCalled();
@@ -869,7 +929,7 @@ describe('NotificationService', () => {
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token-123',
           }),
-        }
+        },
       );
     });
 
@@ -907,7 +967,7 @@ describe('NotificationService', () => {
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token-456',
           }),
-        }
+        },
       );
     });
   });
@@ -924,9 +984,7 @@ describe('NotificationService', () => {
           details: { error: 'DeviceNotRegistered' },
         },
       ];
-      const messages = [
-        { to: 'ExponentPushToken[expired]', title: 'Test', body: 'Body' },
-      ];
+      const messages = [{ to: 'ExponentPushToken[expired]', title: 'Test', body: 'Body' }];
 
       await NotificationService.handleTicketErrors(tickets, messages);
 
@@ -935,12 +993,8 @@ describe('NotificationService', () => {
     });
 
     it('should not clear token for successful tickets', async () => {
-      const tickets = [
-        { status: 'ok' as const, id: 'receipt-1' },
-      ];
-      const messages = [
-        { to: 'ExponentPushToken[valid]', title: 'Test', body: 'Body' },
-      ];
+      const tickets = [{ status: 'ok' as const, id: 'receipt-1' }];
+      const messages = [{ to: 'ExponentPushToken[valid]', title: 'Test', body: 'Body' }];
 
       await NotificationService.handleTicketErrors(tickets, messages);
 
@@ -957,9 +1011,7 @@ describe('NotificationService', () => {
           details: { error: 'DeviceNotRegistered' },
         },
       ];
-      const messages = [
-        { to: 'ExponentPushToken[orphan]', title: 'Test', body: 'Body' },
-      ];
+      const messages = [{ to: 'ExponentPushToken[orphan]', title: 'Test', body: 'Body' }];
 
       await NotificationService.handleTicketErrors(tickets, messages);
 
@@ -976,9 +1028,7 @@ describe('NotificationService', () => {
           details: { error: 'DeviceNotRegistered' },
         },
       ];
-      const messages = [
-        { to: 'ExponentPushToken[broken]', title: 'Test', body: 'Body' },
-      ];
+      const messages = [{ to: 'ExponentPushToken[broken]', title: 'Test', body: 'Body' }];
 
       // Should not throw
       await NotificationService.handleTicketErrors(tickets, messages);

--- a/apps/backend/test/services/reminder-scheduler.service.test.ts
+++ b/apps/backend/test/services/reminder-scheduler.service.test.ts
@@ -807,6 +807,275 @@ describe('ReminderSchedulerService', () => {
     });
   });
 
+  describe('processJournalReminders', () => {
+    it('should process journal reminders and send notifications', async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const mockJournalReminders = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: yesterday.toISOString(),
+          frequency: 'daily',
+          status: 'active',
+          last_sent_at: yesterday.toISOString(),
+          user_device_token: 'ExponentPushToken[zzz]',
+          journal_title: 'My Journal Entry',
+          journal_content: 'Some content here',
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      mockedReminderModel.findDueRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue(
+        mockJournalReminders,
+      );
+      mockedReminderModel.updateLastSentAt.mockResolvedValue(undefined);
+      mockedNotificationService.sendJournalReminderNotification.mockResolvedValue({
+        data: [{ status: 'ok' }],
+      });
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      const results = await ReminderSchedulerService.processReminders();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+      expect(mockedNotificationService.sendJournalReminderNotification).toHaveBeenCalledWith(
+        'ExponentPushToken[zzz]',
+        'My Journal Entry',
+        'Some content here',
+        3,
+        7,
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip journal reminders without device token', async () => {
+      const mockJournalReminders = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: new Date().toISOString(),
+          frequency: 'once',
+          status: 'active',
+          last_sent_at: null,
+          user_device_token: null,
+          journal_title: 'My Journal Entry',
+          journal_content: 'Some content',
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      mockedReminderModel.findDueRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue(
+        mockJournalReminders,
+      );
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const results = await ReminderSchedulerService.processReminders();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toBe('No device token');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should skip journal reminders without title or content', async () => {
+      const mockJournalReminders = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: new Date().toISOString(),
+          frequency: 'once',
+          status: 'active',
+          last_sent_at: null,
+          user_device_token: 'ExponentPushToken[zzz]',
+          journal_title: null,
+          journal_content: null,
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      mockedReminderModel.findDueRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue(
+        mockJournalReminders,
+      );
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const results = await ReminderSchedulerService.processReminders();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toBe('No journal content');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should mark one-time journal reminders as completed after sending', async () => {
+      const mockJournalReminders = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: new Date().toISOString(),
+          frequency: 'once',
+          status: 'active',
+          last_sent_at: null,
+          user_device_token: 'ExponentPushToken[zzz]',
+          journal_title: 'My Journal',
+          journal_content: 'Content',
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      mockedReminderModel.findDueRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue(
+        mockJournalReminders,
+      );
+      mockedReminderModel.markAsCompleted.mockResolvedValue(undefined);
+      mockedNotificationService.sendJournalReminderNotification.mockResolvedValue({
+        data: [{ status: 'ok' }],
+      });
+
+      jest.spyOn(console, 'log').mockImplementation();
+
+      await ReminderSchedulerService.processReminders();
+
+      expect(mockedReminderModel.markAsCompleted).toHaveBeenCalledWith(3);
+    });
+
+    it('should handle journal notification send errors gracefully', async () => {
+      const mockJournalReminders = [
+        {
+          reminder_id: 3,
+          user_id: 1,
+          journal_id: 7,
+          time: new Date().toISOString(),
+          frequency: 'once',
+          status: 'active',
+          last_sent_at: null,
+          user_device_token: 'ExponentPushToken[zzz]',
+          journal_title: 'My Journal',
+          journal_content: 'Content',
+          schedule_times: null,
+          schedule_days: null,
+          timezone: null,
+        },
+      ];
+
+      mockedReminderModel.findDueRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+      mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue(
+        mockJournalReminders,
+      );
+      mockedNotificationService.sendJournalReminderNotification.mockRejectedValue(
+        new Error('API error'),
+      );
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const results = await ReminderSchedulerService.processReminders();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toBe('API error');
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('sendJournalReminderNotification error throw', () => {
+    it('should throw when user_device_token is missing', async () => {
+      const reminder = {
+        reminder_id: 3,
+        user_id: 1,
+        journal_id: 7,
+        time: new Date().toISOString(),
+        frequency: 'daily',
+        status: 'active',
+        last_sent_at: null,
+        user_device_token: null,
+        journal_title: 'Title',
+        journal_content: 'Content',
+        schedule_times: null,
+        schedule_days: null,
+        timezone: null,
+      };
+
+      await expect(
+        ReminderSchedulerService.sendJournalReminderNotification(reminder),
+      ).rejects.toThrow('Missing required notification data');
+    });
+
+    it('should throw when journal_id is missing', async () => {
+      const reminder = {
+        reminder_id: 3,
+        user_id: 1,
+        journal_id: null,
+        time: new Date().toISOString(),
+        frequency: 'daily',
+        status: 'active',
+        last_sent_at: null,
+        user_device_token: 'ExponentPushToken[zzz]',
+        journal_title: 'Title',
+        journal_content: 'Content',
+        schedule_times: null,
+        schedule_days: null,
+        timezone: null,
+      };
+
+      await expect(
+        ReminderSchedulerService.sendJournalReminderNotification(reminder),
+      ).rejects.toThrow('Missing required notification data');
+    });
+
+    it('should throw when both journal_title and journal_content are missing', async () => {
+      const reminder = {
+        reminder_id: 3,
+        user_id: 1,
+        journal_id: 7,
+        time: new Date().toISOString(),
+        frequency: 'daily',
+        status: 'active',
+        last_sent_at: null,
+        user_device_token: 'ExponentPushToken[zzz]',
+        journal_title: null,
+        journal_content: null,
+        schedule_times: null,
+        schedule_days: null,
+        timezone: null,
+      };
+
+      await expect(
+        ReminderSchedulerService.sendJournalReminderNotification(reminder),
+      ).rejects.toThrow('Missing required notification data');
+    });
+  });
+
   describe('validateReminderBase', () => {
     it('should return null for valid reminder with device token', () => {
       const reminder = {

--- a/apps/backend/test/services/reminder-scheduler.service.test.ts
+++ b/apps/backend/test/services/reminder-scheduler.service.test.ts
@@ -24,8 +24,9 @@ describe('ReminderSchedulerService', () => {
     // Reset scheduler state
     ReminderSchedulerService.cronTask = null;
     ReminderSchedulerService.isRunning = false;
-    // Mock collection reminders to return empty by default (for backwards compatibility)
+    // Mock collection and journal reminders to return empty by default (for backwards compatibility)
     mockedReminderModel.findDueCollectionRemindersWithDetails.mockResolvedValue([]);
+    mockedReminderModel.findDueJournalRemindersWithDetails.mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/apps/backend/test/validators/reminder.validator.test.ts
+++ b/apps/backend/test/validators/reminder.validator.test.ts
@@ -33,6 +33,18 @@ describe('Reminder Validators', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should validate with journal_id', () => {
+      const data = {
+        body: {
+          journal_id: 10,
+          time: '2030-01-01T10:00:00Z',
+          frequency: 'daily' as const,
+        },
+      };
+      const result = createReminderSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
     it('should reject when both mantra_id and collection_id are provided', () => {
       const data = {
         body: {
@@ -46,14 +58,39 @@ describe('Reminder Validators', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0].message).toContain(
-          'Exactly one of mantra_id or collection_id must be provided',
+          'Exactly one of mantra_id, collection_id, or journal_id must be provided',
         );
       }
     });
 
-    it('should reject when neither mantra_id nor collection_id is provided', () => {
+    it('should reject when multiple IDs are provided', () => {
       const data = {
         body: {
+          mantra_id: 1,
+          journal_id: 10,
+          time: '2030-01-01T10:00:00Z',
+          frequency: 'daily' as const,
+        },
+      };
+      const result = createReminderSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject when no ID is provided', () => {
+      const data = {
+        body: {
+          time: '2030-01-01T10:00:00Z',
+          frequency: 'daily' as const,
+        },
+      };
+      const result = createReminderSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject negative journal_id', () => {
+      const data = {
+        body: {
+          journal_id: -1,
           time: '2030-01-01T10:00:00Z',
           frequency: 'daily' as const,
         },

--- a/apps/mobile/hooks/useReminders.ts
+++ b/apps/mobile/hooks/useReminders.ts
@@ -11,6 +11,9 @@ export function useReminders() {
   const [remindersByCollection, setRemindersByCollection] = useState<Map<number, ReminderInfo>>(
     new Map(),
   );
+  const [remindersByJournal, setRemindersByJournal] = useState<Map<number, ReminderInfo>>(
+    new Map(),
+  );
 
   const loadReminders = useCallback(async () => {
     try {
@@ -20,6 +23,7 @@ export function useReminders() {
       if (res.status === 'success') {
         const mantraMap = new Map<number, ReminderInfo>();
         const collectionMap = new Map<number, ReminderInfo>();
+        const journalMap = new Map<number, ReminderInfo>();
         for (const r of res.data.reminders) {
           const info: ReminderInfo = { reminder_id: r.reminder_id, status: r.status };
           if (r.mantra_id !== null) {
@@ -28,9 +32,13 @@ export function useReminders() {
           if (r.collection_id !== null) {
             collectionMap.set(r.collection_id, info);
           }
+          if (r.journal_id !== null) {
+            journalMap.set(r.journal_id, info);
+          }
         }
         setRemindersByMantra(mantraMap);
         setRemindersByCollection(collectionMap);
+        setRemindersByJournal(journalMap);
       }
     } catch {
       Alert.alert('Error', 'Failed to load reminders. Please try again later.');
@@ -55,6 +63,13 @@ export function useReminders() {
       return remindersByCollection.get(collectionId);
     },
     [remindersByCollection],
+  );
+
+  const getReminderForJournal = useCallback(
+    (journalId: number): ReminderInfo | undefined => {
+      return remindersByJournal.get(journalId);
+    },
+    [remindersByJournal],
   );
 
   const showReminderActions = useCallback(
@@ -103,24 +118,36 @@ export function useReminders() {
   );
 
   const handleReminderPress = useCallback(
-    (type: 'mantra' | 'collection', id: number, navigation: any) => {
-      const map = type === 'mantra' ? remindersByMantra : remindersByCollection;
+    (type: 'mantra' | 'collection' | 'journal', id: number, navigation: any) => {
+      const map =
+        type === 'mantra'
+          ? remindersByMantra
+          : type === 'collection'
+            ? remindersByCollection
+            : remindersByJournal;
       const existing = map.get(id);
       if (existing) {
         showReminderActions(existing);
       } else {
-        const params = type === 'mantra' ? { mantraId: id } : { collectionId: id };
+        const params =
+          type === 'mantra'
+            ? { mantraId: id }
+            : type === 'collection'
+              ? { collectionId: id }
+              : { journalId: id };
         navigation.navigate('CreateReminder', params);
       }
     },
-    [remindersByMantra, remindersByCollection, showReminderActions],
+    [remindersByMantra, remindersByCollection, remindersByJournal, showReminderActions],
   );
 
   return {
     remindersByMantra,
     remindersByCollection,
+    remindersByJournal,
     getReminderForMantra,
     getReminderForCollection,
+    getReminderForJournal,
     showReminderActions,
     handleReminderPress,
     refresh: loadReminders,

--- a/apps/mobile/screens/CreateReminderScreen.tsx
+++ b/apps/mobile/screens/CreateReminderScreen.tsx
@@ -18,6 +18,7 @@ import { reminderService } from '../services/reminder.service';
 import { mantraService, Mantra } from '../services/mantra.service';
 import { engagementService } from '../services/engagement.service';
 import { collectionService, Collection } from '../services/collection.service';
+import { journalService, JournalEntry } from '../services/journal.service';
 import {
   scheduleSuggestionsService,
   compareTimeSlots,
@@ -50,7 +51,7 @@ const DAYS_OF_WEEK = [
   { key: 'sat', label: 'S', day: 6 },
 ];
 
-type ReminderType = 'mantra' | 'collection';
+type ReminderType = 'mantra' | 'collection' | 'journal';
 
 const TEMPLATES = scheduleSuggestionsService.getTemplates();
 const DAY_PRESETS = scheduleSuggestionsService.getDayPresets();
@@ -62,17 +63,22 @@ export default function CreateReminderScreen() {
 
   const preselectedMantraId = (route.params as any)?.mantraId as number | undefined;
   const preselectedCollectionId = (route.params as any)?.collectionId as number | undefined;
+  const preselectedJournalId = (route.params as any)?.journalId as number | undefined;
 
   const [reminderType, setReminderType] = useState<ReminderType>(
-    preselectedCollectionId ? 'collection' : 'mantra',
+    preselectedJournalId ? 'journal' : preselectedCollectionId ? 'collection' : 'mantra',
   );
   const [selectedMantraId, setSelectedMantraId] = useState<number | undefined>(preselectedMantraId);
   const [selectedCollectionId, setSelectedCollectionId] = useState<number | undefined>(
     preselectedCollectionId,
   );
+  const [selectedJournalId, setSelectedJournalId] = useState<number | undefined>(
+    preselectedJournalId,
+  );
   const [submitting, setSubmitting] = useState(false);
   const [mantras, setMantras] = useState<Mantra[]>([]);
   const [collections, setCollections] = useState<Collection[]>([]);
+  const [journalEntries, setJournalEntries] = useState<JournalEntry[]>([]);
   const [loadingItems, setLoadingItems] = useState(true);
 
   const [scheduleMode, setScheduleMode] = useState<ScheduleMode>('routine');
@@ -106,9 +112,10 @@ export default function CreateReminderScreen() {
       const token = await storage.getToken();
       if (!token) return;
 
-      const [savedMantras, collectionRes] = await Promise.all([
+      const [savedMantras, collectionRes, journalRes] = await Promise.all([
         mantraService.getSavedMantras(token),
         collectionService.getUserCollections(token),
+        journalService.getJournalEntries(token, { limit: 50 }),
       ]);
 
       let mantraList = Array.isArray(savedMantras) ? savedMantras : [];
@@ -127,6 +134,9 @@ export default function CreateReminderScreen() {
       setMantras(mantraList);
       if (collectionRes.data?.collections) {
         setCollections(collectionRes.data.collections);
+      }
+      if (journalRes.data?.entries) {
+        setJournalEntries(journalRes.data.entries);
       }
     } catch (error) {
       console.error('Error loading items:', error);
@@ -322,6 +332,10 @@ export default function CreateReminderScreen() {
       Alert.alert('Select a Collection', 'Please select a collection for this reminder.');
       return;
     }
+    if (reminderType === 'journal' && !selectedJournalId) {
+      Alert.alert('Select a Journal Entry', 'Please select a journal entry for this reminder.');
+      return;
+    }
     if (scheduleMode === 'simple' && time <= new Date()) {
       Alert.alert('Invalid Time', 'Reminder time must be in the future.');
       return;
@@ -337,7 +351,9 @@ export default function CreateReminderScreen() {
       const target =
         reminderType === 'mantra'
           ? { mantra_id: selectedMantraId }
-          : { collection_id: selectedCollectionId };
+          : reminderType === 'collection'
+            ? { collection_id: selectedCollectionId }
+            : { journal_id: selectedJournalId };
 
       if (scheduleMode === 'routine') {
         await reminderService.createReminder(
@@ -372,6 +388,7 @@ export default function CreateReminderScreen() {
 
   const selectedMantra = mantras.find((m) => m.mantra_id === selectedMantraId);
   const selectedCollection = collections.find((c) => c.collection_id === selectedCollectionId);
+  const selectedJournal = journalEntries.find((j) => j.journal_id === selectedJournalId);
 
   // ── iOS modal helpers ──────────────────────────────────────────────────────
 
@@ -506,6 +523,7 @@ export default function CreateReminderScreen() {
               onPress={() => {
                 setReminderType('mantra');
                 setSelectedCollectionId(undefined);
+                setSelectedJournalId(undefined);
               }}
             />
             <TypeToggleButton
@@ -515,6 +533,17 @@ export default function CreateReminderScreen() {
               onPress={() => {
                 setReminderType('collection');
                 setSelectedMantraId(undefined);
+                setSelectedJournalId(undefined);
+              }}
+            />
+            <TypeToggleButton
+              active={reminderType === 'journal'}
+              iconName="book-outline"
+              label="Journal"
+              onPress={() => {
+                setReminderType('journal');
+                setSelectedMantraId(undefined);
+                setSelectedCollectionId(undefined);
               }}
             />
           </View>
@@ -523,7 +552,11 @@ export default function CreateReminderScreen() {
         {/* ── Select item ── */}
         <Section>
           <SectionTitle>
-            {reminderType === 'mantra' ? 'Select Mantra' : 'Select Collection'}
+            {reminderType === 'mantra'
+              ? 'Select Mantra'
+              : reminderType === 'collection'
+                ? 'Select Collection'
+                : 'Select Journal Entry'}
           </SectionTitle>
 
           {loadingItems ? (
@@ -562,33 +595,67 @@ export default function CreateReminderScreen() {
                 ))}
               </ScrollView>
             )
-          ) : collections.length === 0 ? (
+          ) : reminderType === 'collection' ? (
+            collections.length === 0 ? (
+              <AppText className="text-sm text-[#6B7280] italic text-center py-3">
+                No collections yet. Create a collection first.
+              </AppText>
+            ) : (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                className="max-h-[50px]"
+              >
+                {collections.map((collection) => (
+                  <TouchableOpacity
+                    key={collection.collection_id}
+                    className="px-4 py-2 rounded-full mr-2"
+                    style={{
+                      backgroundColor:
+                        selectedCollectionId === collection.collection_id
+                          ? colors.primaryDark
+                          : '#F3F4F6',
+                    }}
+                    onPress={() => setSelectedCollectionId(collection.collection_id)}
+                  >
+                    <AppText
+                      className="text-sm max-w-[150px]"
+                      style={{
+                        color:
+                          selectedCollectionId === collection.collection_id ? colors.text : '#333',
+                      }}
+                      numberOfLines={1}
+                    >
+                      {collection.name}
+                    </AppText>
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            )
+          ) : journalEntries.length === 0 ? (
             <AppText className="text-sm text-[#6B7280] italic text-center py-3">
-              No collections yet. Create a collection first.
+              No journal entries yet. Write a journal entry first.
             </AppText>
           ) : (
             <ScrollView horizontal showsHorizontalScrollIndicator={false} className="max-h-[50px]">
-              {collections.map((collection) => (
+              {journalEntries.map((entry) => (
                 <TouchableOpacity
-                  key={collection.collection_id}
+                  key={entry.journal_id}
                   className="px-4 py-2 rounded-full mr-2"
                   style={{
                     backgroundColor:
-                      selectedCollectionId === collection.collection_id
-                        ? colors.primaryDark
-                        : '#F3F4F6',
+                      selectedJournalId === entry.journal_id ? colors.primaryDark : '#F3F4F6',
                   }}
-                  onPress={() => setSelectedCollectionId(collection.collection_id)}
+                  onPress={() => setSelectedJournalId(entry.journal_id)}
                 >
                   <AppText
                     className="text-sm max-w-[150px]"
                     style={{
-                      color:
-                        selectedCollectionId === collection.collection_id ? colors.text : '#333',
+                      color: selectedJournalId === entry.journal_id ? colors.text : '#333',
                     }}
                     numberOfLines={1}
                   >
-                    {collection.name}
+                    {entry.title || entry.content.substring(0, 30)}
                   </AppText>
                 </TouchableOpacity>
               ))}
@@ -614,6 +681,17 @@ export default function CreateReminderScreen() {
               <Ionicons name="checkmark-circle" size={16} color={colors.primaryDark} />
               <AppText className="text-sm text-[#333] flex-1" numberOfLines={1}>
                 {selectedCollection.name}
+              </AppText>
+            </View>
+          )}
+          {selectedJournal && (
+            <View
+              className="flex-row items-center gap-2 mt-3 pt-3 border-t border-[#F3F4F6]"
+              testID="selected-item-preview"
+            >
+              <Ionicons name="checkmark-circle" size={16} color={colors.primaryDark} />
+              <AppText className="text-sm text-[#333] flex-1" numberOfLines={2}>
+                {selectedJournal.title || selectedJournal.content.substring(0, 50)}
               </AppText>
             </View>
           )}

--- a/apps/mobile/screens/JournalScreen.tsx
+++ b/apps/mobile/screens/JournalScreen.tsx
@@ -13,6 +13,7 @@ import AppText from '../components/UI/textWrapper';
 import { journalService, JournalEntry, MOOD_OPTIONS } from '../services/journal.service';
 import { storage } from '../utils/storage';
 import { useFocusEffect } from '@react-navigation/native';
+import { useReminders } from '../hooks/useReminders';
 
 export default function JournalScreen({ navigation }: any) {
   const { colors } = useTheme();
@@ -20,6 +21,7 @@ export default function JournalScreen({ navigation }: any) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [totalEntries, setTotalEntries] = useState(0);
+  const { remindersByJournal, handleReminderPress } = useReminders();
 
   const loadJournalEntries = async () => {
     try {
@@ -120,6 +122,21 @@ export default function JournalScreen({ navigation }: any) {
               <AppText className="text-2xl">{getMoodEmoji(item.mood)}</AppText>
             </View>
           )}
+          <TouchableOpacity
+            testID={`journal-reminder-${item.journal_id}`}
+            className="p-1"
+            onPress={() => handleReminderPress('journal', item.journal_id, navigation)}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Ionicons
+              name={
+                remindersByJournal.has(item.journal_id) ? 'notifications' : 'notifications-outline'
+              }
+              size={18}
+              color={colors.text}
+              style={{ opacity: 0.5 }}
+            />
+          </TouchableOpacity>
           <TouchableOpacity
             testID="delete-button"
             className="p-1"

--- a/apps/mobile/screens/RemindersScreen.tsx
+++ b/apps/mobile/screens/RemindersScreen.tsx
@@ -119,8 +119,14 @@ export default function RemindersScreen() {
 
   const renderReminder = ({ item }: { item: Reminder }) => {
     const isMantra = item.mantra_id !== null;
-    const typeLabel = isMantra ? 'Mantra' : 'Collection';
-    const linkedName = isMantra ? item.mantra_title : item.collection_name;
+    const isJournal = item.journal_id !== null;
+    const typeLabel = isMantra ? 'Mantra' : isJournal ? 'Journal' : 'Collection';
+    const typeIcon = isMantra ? 'leaf-outline' : isJournal ? 'book-outline' : 'folder-outline';
+    const linkedName = isMantra
+      ? item.mantra_title
+      : isJournal
+        ? item.journal_title
+        : item.collection_name;
     const isActive = item.status === 'active';
     const isCompleted = item.status === 'completed';
     const isRoutine = item.frequency === 'routine';
@@ -133,14 +139,10 @@ export default function RemindersScreen() {
         {/* Header row: type badge + status badge */}
         <View className="flex-row justify-between items-center mb-3">
           <View
-            className="flex-row items-center gap-1 px-2.5 py-1 rounded-xl"
+            className="flex-row items-center gap-2 px-2.5 py-1 rounded-xl"
             style={{ backgroundColor: colors.primaryDark + '22' }}
           >
-            <Ionicons
-              name={isMantra ? 'leaf-outline' : 'folder-outline'}
-              size={14}
-              color={colors.primaryDark}
-            />
+            <Ionicons name={typeIcon as any} size={14} color={colors.primaryDark} />
             <AppText className="text-xs" style={{ color: colors.primaryDark }}>
               {typeLabel}
             </AppText>
@@ -215,7 +217,7 @@ export default function RemindersScreen() {
         {!isCompleted && (
           <View className="flex-row border-t border-[#F3F4F6] pt-3 gap-4">
             <TouchableOpacity
-              className="flex-row items-center gap-1"
+              className="flex-row items-center gap-2"
               onPress={() => handleToggleStatus(item)}
             >
               <Ionicons
@@ -228,7 +230,7 @@ export default function RemindersScreen() {
               </AppText>
             </TouchableOpacity>
             <TouchableOpacity
-              className="flex-row items-center gap-1"
+              className="flex-row items-center gap-2"
               onPress={() => handleDelete(item)}
             >
               <Ionicons name="trash-outline" size={20} color="#EF4444" />
@@ -282,7 +284,8 @@ export default function RemindersScreen() {
             className="text-[15px] text-center leading-[22px] mb-6 opacity-80"
             style={{ color: colors.text }}
           >
-            Create a reminder to get notified about your favourite mantras or collections.
+            Create a reminder to get notified about your favourite mantras, collections, or journal
+            entries.
           </AppText>
           <TouchableOpacity
             className="py-3.5 px-8 rounded-xl"

--- a/apps/mobile/services/reminder.service.ts
+++ b/apps/mobile/services/reminder.service.ts
@@ -5,12 +5,14 @@ export type Reminder = {
   user_id: number | null;
   mantra_id: number | null;
   collection_id: number | null;
+  journal_id: number | null;
   time: string | null;
   frequency: string | null;
   status: string | null;
   last_sent_at: string | null;
   mantra_title: string | null;
   collection_name: string | null;
+  journal_title: string | null;
   schedule_times: string[] | null;
   schedule_days: number[] | null;
   timezone: string | null;
@@ -39,6 +41,7 @@ export interface MessageResponse {
 export interface CreateReminderInput {
   mantra_id?: number;
   collection_id?: number;
+  journal_id?: number;
   time?: string;
   frequency: 'once' | 'daily' | 'weekly' | 'monthly' | 'custom' | 'routine';
   status?: 'active' | 'paused';
@@ -50,6 +53,7 @@ export interface CreateReminderInput {
 export interface UpdateReminderInput {
   mantra_id?: number;
   collection_id?: number;
+  journal_id?: number;
   time?: string;
   frequency?: 'once' | 'daily' | 'weekly' | 'monthly' | 'custom' | 'routine';
   status?: 'active' | 'paused' | 'completed';

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -15,7 +15,7 @@ export type RootStackParamList = {
   Liked: undefined;
   Settings: undefined;
   Reminders: undefined;
-  CreateReminder: { mantraId?: number; collectionId?: number } | undefined;
+  CreateReminder: { mantraId?: number; collectionId?: number; journalId?: number } | undefined;
   MantraAlgorithm: undefined;
   Themes: undefined;
 };

--- a/apps/mobile/test/hooks/useReminders.test.ts
+++ b/apps/mobile/test/hooks/useReminders.test.ts
@@ -471,6 +471,113 @@ describe('useReminders', () => {
     expect(reminderService.deleteReminder).not.toHaveBeenCalled();
   });
 
+  it('populates remindersByJournal map', async () => {
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: {
+        reminders: [
+          {
+            reminder_id: 1,
+            mantra_id: null,
+            collection_id: null,
+            journal_id: 50,
+            status: 'active',
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useReminders());
+
+    await waitFor(() => {
+      expect(result.current.remindersByJournal.size).toBe(1);
+    });
+
+    expect(result.current.remindersByJournal.get(50)).toEqual({
+      reminder_id: 1,
+      status: 'active',
+    });
+  });
+
+  it('getReminderForJournal returns the correct reminder', async () => {
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: {
+        reminders: [
+          {
+            reminder_id: 8,
+            mantra_id: null,
+            collection_id: null,
+            journal_id: 25,
+            status: 'active',
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useReminders());
+
+    await waitFor(() => {
+      expect(result.current.remindersByJournal.size).toBe(1);
+    });
+
+    expect(result.current.getReminderForJournal(25)).toEqual({
+      reminder_id: 8,
+      status: 'active',
+    });
+    expect(result.current.getReminderForJournal(999)).toBeUndefined();
+  });
+
+  it('handleReminderPress navigates to CreateReminder when no reminder exists for journal', async () => {
+    const mockNavigate = jest.fn();
+    const navigation = { navigate: mockNavigate };
+
+    const { result } = renderHook(() => useReminders());
+
+    await waitFor(() => {
+      expect(reminderService.getReminders).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.handleReminderPress('journal', 50, navigation);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('CreateReminder', { journalId: 50 });
+  });
+
+  it('handleReminderPress shows alert when journal reminder exists', async () => {
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: {
+        reminders: [
+          {
+            reminder_id: 9,
+            mantra_id: null,
+            collection_id: null,
+            journal_id: 30,
+            status: 'active',
+          },
+        ],
+      },
+    });
+
+    const mockNavigate = jest.fn();
+    const navigation = { navigate: mockNavigate };
+
+    const { result } = renderHook(() => useReminders());
+
+    await waitFor(() => {
+      expect(result.current.remindersByJournal.size).toBe(1);
+    });
+
+    act(() => {
+      result.current.handleReminderPress('journal', 30, navigation);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith('Reminder', undefined, expect.any(Array));
+  });
+
   it('does not update state when response status is not success', async () => {
     (reminderService.getReminders as jest.Mock).mockResolvedValue({
       status: 'error',

--- a/apps/mobile/test/screens/CreateReminderScreen.test.tsx
+++ b/apps/mobile/test/screens/CreateReminderScreen.test.tsx
@@ -5,6 +5,7 @@ import CreateReminderScreen from '../../screens/CreateReminderScreen';
 import { reminderService } from '../../services/reminder.service';
 import { mantraService } from '../../services/mantra.service';
 import { collectionService } from '../../services/collection.service';
+import { journalService } from '../../services/journal.service';
 import { storage } from '../../utils/storage';
 
 jest.mock('@expo/vector-icons', () => ({
@@ -59,6 +60,13 @@ jest.mock('../../services/collection.service', () => ({
   },
 }));
 
+jest.mock('../../services/journal.service', () => ({
+  journalService: {
+    getJournalEntries: jest.fn(),
+  },
+  MOOD_OPTIONS: [],
+}));
+
 jest.mock('../../utils/storage', () => ({
   storage: {
     getToken: jest.fn(),
@@ -96,6 +104,10 @@ describe('CreateReminderScreen', () => {
     (collectionService.getUserCollections as jest.Mock).mockResolvedValue({
       status: 'success',
       data: { collections: mockCollections },
+    });
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: [] },
     });
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 

--- a/apps/mobile/test/screens/CreateReminderScreen.test.tsx
+++ b/apps/mobile/test/screens/CreateReminderScreen.test.tsx
@@ -1379,4 +1379,183 @@ describe('CreateReminderScreen', () => {
     // Instead, just verify the preset change was accepted and no errors occurred
     expect(getByText('Weekends')).toBeTruthy();
   });
+
+  it('switches to journal type and shows journal entries', async () => {
+    const mockJournalEntries = [
+      {
+        journal_id: 100,
+        title: 'Morning Reflection',
+        content: 'Today I felt grateful',
+        created_at: '2024-01-01T08:00:00Z',
+        updated_at: '2024-01-01T08:00:00Z',
+        user_id: 1,
+        mantra_id: null,
+        mood: null,
+        tags: [],
+        is_private: false,
+      },
+    ];
+
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockJournalEntries },
+    });
+
+    const { getByText } = render(<CreateReminderScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Be Present')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Journal'));
+
+    await waitFor(() => {
+      expect(getByText('Morning Reflection')).toBeTruthy();
+    });
+  });
+
+  it('preselects journal type when journalId is in route params', async () => {
+    mockRouteParams = { journalId: 100 };
+
+    const mockJournalEntries = [
+      {
+        journal_id: 100,
+        title: 'My Entry',
+        content: 'Content here',
+        created_at: '2024-01-01T08:00:00Z',
+        updated_at: '2024-01-01T08:00:00Z',
+        user_id: 1,
+        mantra_id: null,
+        mood: null,
+        tags: [],
+        is_private: false,
+      },
+    ];
+
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockJournalEntries },
+    });
+
+    const { getAllByText } = render(<CreateReminderScreen />);
+
+    await waitFor(() => {
+      // Entry appears in both the list and the selected preview
+      expect(getAllByText('My Entry').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('shows alert when trying to submit journal reminder without selection', async () => {
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: [] },
+    });
+
+    const { getByText, getByTestId } = render(<CreateReminderScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Be Present')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Journal'));
+
+    // Try to submit without selecting a journal entry
+    fireEvent.press(getByTestId('create-reminder-button'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Select a Journal Entry',
+        'Please select a journal entry for this reminder.',
+      );
+    });
+  });
+
+  it('creates a journal reminder successfully', async () => {
+    const mockJournalEntries = [
+      {
+        journal_id: 200,
+        title: 'Evening Thoughts',
+        content: 'Reflecting on the day',
+        created_at: '2024-01-01T20:00:00Z',
+        updated_at: '2024-01-01T20:00:00Z',
+        user_id: 1,
+        mantra_id: null,
+        mood: null,
+        tags: [],
+        is_private: false,
+      },
+    ];
+
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockJournalEntries },
+    });
+
+    (reminderService.createReminder as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { reminder: { reminder_id: 99 } },
+    });
+
+    const { getByText, getByTestId } = render(<CreateReminderScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Be Present')).toBeTruthy();
+    });
+
+    // Switch to journal type
+    fireEvent.press(getByText('Journal'));
+
+    await waitFor(() => {
+      expect(getByText('Evening Thoughts')).toBeTruthy();
+    });
+
+    // Select the journal entry
+    fireEvent.press(getByText('Evening Thoughts'));
+
+    // Submit
+    fireEvent.press(getByTestId('create-reminder-button'));
+
+    await waitFor(() => {
+      expect(reminderService.createReminder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          journal_id: 200,
+        }),
+        'test-token',
+      );
+    });
+  });
+
+  it('displays journal entry content as fallback when title is null', async () => {
+    const mockJournalEntries = [
+      {
+        journal_id: 300,
+        title: null,
+        content: 'Some untitled journal content here that should display',
+        created_at: '2024-01-01T08:00:00Z',
+        updated_at: '2024-01-01T08:00:00Z',
+        user_id: 1,
+        mantra_id: null,
+        mood: null,
+        tags: [],
+        is_private: false,
+      },
+    ];
+
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockJournalEntries },
+    });
+
+    const { getByText } = render(<CreateReminderScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Be Present')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Journal'));
+
+    await waitFor(() => {
+      expect(getByText(/Some untitled journal content/)).toBeTruthy();
+    });
+  });
 });

--- a/apps/mobile/test/screens/JournalScreen.test.tsx
+++ b/apps/mobile/test/screens/JournalScreen.test.tsx
@@ -29,6 +29,20 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+jest.mock('../../hooks/useReminders', () => ({
+  useReminders: () => ({
+    remindersByMantra: new Map(),
+    remindersByCollection: new Map(),
+    remindersByJournal: new Map(),
+    getReminderForMantra: jest.fn(),
+    getReminderForCollection: jest.fn(),
+    getReminderForJournal: jest.fn(),
+    showReminderActions: jest.fn(),
+    handleReminderPress: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
 jest.mock('../../context/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/apps/mobile/test/screens/JournalScreen.test.tsx
+++ b/apps/mobile/test/screens/JournalScreen.test.tsx
@@ -29,16 +29,19 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+const mockHandleReminderPress = jest.fn();
+const mockRemindersByJournal = new Map();
+
 jest.mock('../../hooks/useReminders', () => ({
   useReminders: () => ({
     remindersByMantra: new Map(),
     remindersByCollection: new Map(),
-    remindersByJournal: new Map(),
+    remindersByJournal: mockRemindersByJournal,
     getReminderForMantra: jest.fn(),
     getReminderForCollection: jest.fn(),
     getReminderForJournal: jest.fn(),
     showReminderActions: jest.fn(),
-    handleReminderPress: jest.fn(),
+    handleReminderPress: mockHandleReminderPress,
     refresh: jest.fn(),
   }),
 }));
@@ -102,6 +105,7 @@ describe('JournalScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRemindersByJournal.clear();
     (storage.getToken as jest.Mock).mockResolvedValue('mock-token');
     jest.spyOn(Alert, 'alert').mockImplementation((title, message, buttons) => {
       if (buttons && buttons.length > 0) {
@@ -332,6 +336,41 @@ describe('JournalScreen', () => {
       expect(getByText('#mindfulness')).toBeTruthy();
       expect(getByText('#peace')).toBeTruthy();
     });
+  });
+
+  it('renders reminder bell icon for each journal entry', async () => {
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockEntries, pagination: { total: 2 } },
+    });
+
+    const { getByTestId } = render(<JournalScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await waitFor(() => {
+      expect(getByTestId(`journal-reminder-${mockEntries[0].journal_id}`)).toBeTruthy();
+      expect(getByTestId(`journal-reminder-${mockEntries[1].journal_id}`)).toBeTruthy();
+    });
+  });
+
+  it('calls handleReminderPress when bell icon is pressed', async () => {
+    (journalService.getJournalEntries as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { entries: mockEntries, pagination: { total: 2 } },
+    });
+
+    const { getByTestId } = render(<JournalScreen navigation={mockNavigation} route={mockRoute} />);
+
+    await waitFor(() => {
+      expect(getByTestId(`journal-reminder-${mockEntries[0].journal_id}`)).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId(`journal-reminder-${mockEntries[0].journal_id}`));
+
+    expect(mockHandleReminderPress).toHaveBeenCalledWith(
+      'journal',
+      mockEntries[0].journal_id,
+      mockNavigation,
+    );
   });
 
   it('truncates long content', async () => {

--- a/apps/mobile/test/screens/RemindersScreen.test.tsx
+++ b/apps/mobile/test/screens/RemindersScreen.test.tsx
@@ -49,24 +49,28 @@ describe('RemindersScreen', () => {
       user_id: 1,
       mantra_id: 10,
       collection_id: null,
+      journal_id: null,
       time: '2024-06-15T10:00:00Z',
       frequency: 'daily',
       status: 'active',
       last_sent_at: null,
       mantra_title: 'Be Present',
       collection_name: null,
+      journal_title: null,
     },
     {
       reminder_id: 2,
       user_id: 1,
       mantra_id: null,
       collection_id: 5,
+      journal_id: null,
       time: '2024-06-15T14:30:00Z',
       frequency: 'weekly',
       status: 'paused',
       last_sent_at: null,
       mantra_title: null,
       collection_name: 'Morning Mantras',
+      journal_title: null,
     },
   ];
 
@@ -91,7 +95,9 @@ describe('RemindersScreen', () => {
     await waitFor(() => {
       expect(getByText('No reminders yet')).toBeTruthy();
       expect(
-        getByText('Create a reminder to get notified about your favourite mantras or collections.'),
+        getByText(
+          'Create a reminder to get notified about your favourite mantras, collections, or journal entries.',
+        ),
       ).toBeTruthy();
       expect(getByText('Create Reminder')).toBeTruthy();
     });

--- a/apps/mobile/test/screens/RemindersScreen.test.tsx
+++ b/apps/mobile/test/screens/RemindersScreen.test.tsx
@@ -529,6 +529,66 @@ describe('RemindersScreen', () => {
     });
   });
 
+  it('displays journal type reminder correctly', async () => {
+    const journalReminder = {
+      reminder_id: 5,
+      user_id: 1,
+      mantra_id: null,
+      collection_id: null,
+      journal_id: 7,
+      time: '2024-06-15T10:00:00Z',
+      frequency: 'daily',
+      status: 'active',
+      last_sent_at: null,
+      mantra_title: null,
+      collection_name: null,
+      journal_title: 'My Journal Entry',
+    };
+
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { reminders: [journalReminder] },
+    });
+
+    const { getByText } = render(<RemindersScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Journal')).toBeTruthy();
+      expect(getByText('My Journal Entry')).toBeTruthy();
+    });
+  });
+
+  it('displays journal reminder without title (no linked name shown)', async () => {
+    const journalReminder = {
+      reminder_id: 6,
+      user_id: 1,
+      mantra_id: null,
+      collection_id: null,
+      journal_id: 8,
+      time: '2024-06-15T10:00:00Z',
+      frequency: 'weekly',
+      status: 'active',
+      last_sent_at: null,
+      mantra_title: null,
+      collection_name: null,
+      journal_title: null,
+    };
+
+    (reminderService.getReminders as jest.Mock).mockResolvedValue({
+      status: 'success',
+      data: { reminders: [journalReminder] },
+    });
+
+    const { getByText, queryByText } = render(<RemindersScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Journal')).toBeTruthy();
+    });
+
+    // No linked name should be shown
+    expect(queryByText('My Journal Entry')).toBeNull();
+  });
+
   it('displays "No times set" for routine reminders without schedule_times', async () => {
     const routineReminder = {
       reminder_id: 4,


### PR DESCRIPTION
## Summary
Added Reminders for Journal entries. Includes 
- Create database migration for journal_id on Reminder table
- Update database types (ReminderTable) with journal_id
- Update reminder validator to accept journal_id
- Update reminder model with journal query methods
- Update reminder controller for journal reminders
- Update notification service for journal reminders
- Update reminder scheduler for journal reminders
- Update mobile reminder service types for journal_id
- Update CreateReminderScreen with journal option
- Update RemindersScreen to display journal reminders
- Update navigation types for journal reminder param

## Linked Story
Closes #525 

## Changes
- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Other

## Evidence
- Screenshots / GIFs (if UI)
- Demo link (if applicable)

## Tests
- [x] Unit tests added/updated
- [x] CI passing

## Notes
Co-authored-by: @username (if pair/mob programming)
