### PR TITLE
Keep verification code screen after app is closed and reopened  

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -68,27 +68,6 @@ export default function MainNavigator() {
     checkAuth();
   }, []);
 
-  // Navigate back to verification screen if there's a pending code
-  useEffect(() => {
-    if (!pendingVerification || isLoggedIn) return;
-
-    const navigateToPendingVerification = async () => {
-      let attempts = 0;
-      while (!isNavigationReady() && attempts < 20) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        attempts++;
-      }
-      if (isNavigationReady()) {
-        navigateFromOutside('VerifyCode', {
-          email: pendingVerification.email,
-          flow: pendingVerification.flow,
-        });
-      }
-    };
-
-    navigateToPendingVerification();
-  }, [pendingVerification, isLoggedIn]);
-
   // Set up push notifications when user is logged in
   useEffect(() => {
     if (isLoggedIn) {
@@ -286,7 +265,7 @@ export default function MainNavigator() {
     <ThemeProvider>
       <SavedProvider>
         <Stack.Navigator
-          initialRouteName={isLoggedIn ? 'MainApp' : 'Login'}
+          initialRouteName={pendingVerification ? 'VerifyCode' : isLoggedIn ? 'MainApp' : 'Login'}
           screenOptions={{
             headerShown: false,
           }}
@@ -352,6 +331,7 @@ export default function MainNavigator() {
           <Stack.Screen
             name="VerifyCode"
             component={VerifyCodeScreen}
+            initialParams={pendingVerification ?? undefined}
             options={{ headerTitle: 'Verify Code' }}
           />
           <Stack.Screen

--- a/apps/mobile/screens/VerifyCodeScreen.tsx
+++ b/apps/mobile/screens/VerifyCodeScreen.tsx
@@ -21,15 +21,32 @@ export default function VerifyCodeScreen({ route, navigation }: any) {
 
   const [code, setCode] = useState(['', '', '', '', '', '']);
   const [loading, setLoading] = useState(false);
-  const [resendCooldown, setResendCooldown] = useState(60); // Start with 60 seconds cooldown
+  const [resendCooldown, setResendCooldown] = useState(60);
+  const [codeExpiresAt, setCodeExpiresAt] = useState(Date.now() + 10 * 60 * 1000);
+  const [secondsLeft, setSecondsLeft] = useState(10 * 60);
   const { colors } = useTheme();
 
   const inputRefs = useRef<Array<TextInput | null>>([]);
 
-  // Persist verification state so the user returns here if they leave the app
+  // Persist verification state and sync the expiry timer with what's in storage
   useEffect(() => {
-    storage.savePendingVerification(email, flow);
+    storage.getPendingVerification().then((pending) => {
+      if (pending) {
+        setCodeExpiresAt(pending.expiresAt);
+      } else {
+        storage.savePendingVerification(email, flow);
+      }
+    });
   }, [email, flow]);
+
+  // Live countdown tied to codeExpiresAt — resets whenever a new code is sent
+  useEffect(() => {
+    setSecondsLeft(Math.max(0, Math.floor((codeExpiresAt - Date.now()) / 1000)));
+    const interval = setInterval(() => {
+      setSecondsLeft(Math.max(0, Math.floor((codeExpiresAt - Date.now()) / 1000)));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [codeExpiresAt]);
 
   // Countdown for resend cooldown
   useEffect(() => {
@@ -124,6 +141,8 @@ export default function VerifyCodeScreen({ route, navigation }: any) {
 
       if (response.status === 'success') {
         Alert.alert('Success', 'A new verification code has been sent to your email');
+        storage.savePendingVerification(email, flow);
+        setCodeExpiresAt(Date.now() + 10 * 60 * 1000);
         setResendCooldown(60);
         setCode(['', '', '', '', '', '']);
         inputRefs.current[0]?.focus();
@@ -175,8 +194,16 @@ export default function VerifyCodeScreen({ route, navigation }: any) {
                   ? `We've sent a 6-digit code to ${email}. Enter it below to continue.`
                   : `We've sent a 6-digit code to ${email}`}
               </AppText>
-              <AppText className="text-[#ffffff] text-[12px] text-center mb-[20px] opacity-70">
-                Code expires in 10 minutes
+              <AppText
+                className="text-[12px] text-center mb-[20px]"
+                style={{
+                  color: secondsLeft < 60 ? '#ff6b6b' : '#ffffff',
+                  opacity: secondsLeft < 60 ? 1 : 0.7,
+                }}
+              >
+                {secondsLeft > 0
+                  ? `Code expires in ${Math.floor(secondsLeft / 60)}:${(secondsLeft % 60).toString().padStart(2, '0')}`
+                  : 'Code has expired — please request a new one'}
               </AppText>
 
               {/* 6-digit code input */}

--- a/apps/mobile/test/screens/VerifyCodeScreen.test.tsx
+++ b/apps/mobile/test/screens/VerifyCodeScreen.test.tsx
@@ -9,6 +9,7 @@ jest.mock('../../utils/storage', () => ({
   storage: {
     savePendingVerification: jest.fn(() => Promise.resolve()),
     clearPendingVerification: jest.fn(() => Promise.resolve()),
+    getPendingVerification: jest.fn(() => Promise.resolve(null)),
   },
 }));
 
@@ -80,7 +81,7 @@ describe('VerifyCodeScreen', () => {
 
     expect(getByText('Enter Verification Code')).toBeTruthy();
     expect(getByText("We've sent a 6-digit code to user@example.com")).toBeTruthy();
-    expect(getByText('Code expires in 10 minutes')).toBeTruthy();
+    expect(getByText(/Code expires in \d+:\d{2}/)).toBeTruthy();
     expect(getByText('Verify Code')).toBeTruthy();
     expect(getByText(/Didn't receive the code?/)).toBeTruthy();
 
@@ -751,13 +752,15 @@ describe('VerifyCodeScreen', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('saves pending verification state on mount', () => {
+  it('saves pending verification state on mount', async () => {
     render(<VerifyCodeScreen route={mockRoute} navigation={mockNavigation} />);
 
-    expect(storage.savePendingVerification).toHaveBeenCalledWith(
-      'user@example.com',
-      'forgotPassword',
-    );
+    await waitFor(() => {
+      expect(storage.savePendingVerification).toHaveBeenCalledWith(
+        'user@example.com',
+        'forgotPassword',
+      );
+    });
   });
 
   it('clears pending verification state after successful verification', async () => {

--- a/apps/mobile/test/screens/VerifyCodeScreen.test.tsx
+++ b/apps/mobile/test/screens/VerifyCodeScreen.test.tsx
@@ -803,4 +803,98 @@ describe('VerifyCodeScreen', () => {
 
     expect(getByText(/Resend in 58s/)).toBeTruthy();
   });
+
+  it('restores expiry timer from storage when pending verification exists', async () => {
+    const futureExpiry = Date.now() + 5 * 60 * 1000; // 5 minutes remaining
+    (storage.getPendingVerification as jest.Mock).mockResolvedValueOnce({
+      email: 'user@example.com',
+      flow: 'forgotPassword',
+      expiresAt: futureExpiry,
+    });
+
+    const { getByText } = render(
+      <VerifyCodeScreen route={mockRoute} navigation={mockNavigation} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText(/Code expires in 4:\d{2}|5:00/)).toBeTruthy();
+    });
+  });
+
+  it('navigates to CompleteSignUp on successful signup flow verification', async () => {
+    (authService.verifySignupCode as jest.Mock).mockResolvedValue({
+      status: 'success',
+      message: 'Code verified',
+    });
+
+    const signupRoute = { params: { email: 'user@example.com', flow: 'signup' } };
+    const container = render(<VerifyCodeScreen route={signupRoute} navigation={mockNavigation} />);
+
+    const inputs = container.getAllByDisplayValue('');
+    fireEvent.changeText(inputs[0], '1');
+    fireEvent.changeText(inputs[1], '2');
+    fireEvent.changeText(inputs[2], '3');
+    fireEvent.changeText(inputs[3], '4');
+    fireEvent.changeText(inputs[4], '5');
+    fireEvent.changeText(inputs[5], '6');
+
+    await waitFor(() => {
+      expect(mockNavigation.navigate).toHaveBeenCalledWith('CompleteSignUp', {
+        email: 'user@example.com',
+        code: '123456',
+      });
+    });
+  });
+
+  it('resends signup code when in signup flow', async () => {
+    (authService.sendSignupCode as jest.Mock).mockResolvedValue({
+      status: 'success',
+      message: 'Code sent',
+    });
+
+    const signupRoute = { params: { email: 'user@example.com', flow: 'signup' } };
+    const container = render(<VerifyCodeScreen route={signupRoute} navigation={mockNavigation} />);
+
+    for (let i = 0; i < 60; i++) {
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    }
+
+    await waitFor(() => {
+      const button = getResendButton(container);
+      if (button) fireEvent.press(button);
+    });
+
+    await waitFor(() => {
+      expect(authService.sendSignupCode).toHaveBeenCalledWith('user@example.com');
+    });
+  });
+
+  it('does not resend code when cooldown is still active', async () => {
+    const container = render(<VerifyCodeScreen route={mockRoute} navigation={mockNavigation} />);
+
+    // Cooldown is 60s on mount — pressing resend should do nothing
+    const resendText = container.getByText(/Resend in 60s/);
+    fireEvent.press(resendText);
+
+    expect(authService.forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('shows expired message when code timer reaches zero', async () => {
+    const expiredExpiry = Date.now() - 1000; // already expired
+    (storage.getPendingVerification as jest.Mock).mockResolvedValueOnce({
+      email: 'user@example.com',
+      flow: 'forgotPassword',
+      expiresAt: expiredExpiry,
+    });
+
+    const { getByText } = render(
+      <VerifyCodeScreen route={mockRoute} navigation={mockNavigation} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Code has expired — please request a new one')).toBeTruthy();
+    });
+  });
 });

--- a/apps/mobile/utils/storage.ts
+++ b/apps/mobile/utils/storage.ts
@@ -85,7 +85,11 @@ export const storage = {
     await AsyncStorage.setItem(PENDING_VERIFICATION_KEY, JSON.stringify(data));
   },
 
-  async getPendingVerification(): Promise<{ email: string; flow: string } | null> {
+  async getPendingVerification(): Promise<{
+    email: string;
+    flow: string;
+    expiresAt: number;
+  } | null> {
     const raw = await AsyncStorage.getItem(PENDING_VERIFICATION_KEY);
     if (!raw) return null;
     const data = JSON.parse(raw) as PendingVerification;
@@ -93,7 +97,7 @@ export const storage = {
       await AsyncStorage.removeItem(PENDING_VERIFICATION_KEY);
       return null;
     }
-    return { email: data.email, flow: data.flow };
+    return { email: data.email, flow: data.flow, expiresAt: data.expiresAt };
   },
 
   async clearPendingVerification(): Promise<void> {


### PR DESCRIPTION
## Summary
Fixes the verification code screen not persisting when the app is force-closed. Previously, the app would always reopen to   Login, forcing users to request a new code. The fix reads the pending verification state before the navigation stack renders, so the app lands directly on the correct screen within the 10-minute code window. A live countdown timer was also added to the screen, showing the real remaining time and resetting when a new code is requested.  

## Linked Story
Closes #535

## Changes
- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Other

## Evidence
- Screenshots / GIFs (if UI)
- Demo link (if applicable)

## Tests
- [ ] Unit tests added/updated
- [x] CI passing

## Notes
Co-authored-by: @username (if pair/mob programming)
